### PR TITLE
Add codeowners

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,0 +1,2 @@
+# Please keep this file sorted
+* @KirillLykov


### PR DESCRIPTION
Add codeowners file to manage PR review approvals. Initially assigning to Kirill until we figure out who should be the longer term owners.