### PR TITLE
Split the work in csv writer amond several tasks

### DIFF
--- a/rate-latency-tool/src/run_client.rs
+++ b/rate-latency-tool/src/run_client.rs
@@ -36,7 +36,8 @@ use {
     },
 };
 
-const CSV_RECORD_CHANNEL_SIZE: usize = 128;
+/// Size of the channel for sending CSV records from the transaction sender.
+const CSV_RECORD_CHANNEL_SIZE: usize = 1024;
 
 /// Memo transcaction CU price depends on the message size, but generally it is
 /// in range 9000-20000.


### PR DESCRIPTION
Currently, when we download all the transactions for the analysis, the csv_writer is not able to add information to `tx_status` as expected. It happens because there is one task that does too much.
Hence, split the work done within one task in csv_writer with `select!` into several tasks. 
