### PR TITLE
rate-latency-tool: use ensure worker

### DIFF
--- a/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
+++ b/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
@@ -63,23 +63,16 @@ where
             // add future leaders to the cache to hide the latency of opening
             // the connection.
             for peer in connect_leaders {
-                debug!("Checking connection to the peer: {peer}");
-                if !workers.contains(&peer) {
-                    debug!("Creating connection to the peer: {peer}");
-                    let worker = spawn_worker(
-                        &endpoint,
-                        &peer,
-                        worker_channel_size,
-                        skip_check_transaction_age,
-                        max_reconnect_attempts,
-                        handshake_timeout,
-                        stats.clone(),
-                    );
-                    if let Some(pop_worker) = workers.push(peer, worker) {
-                        shutdown_worker(pop_worker)
-                    }
-                } else {
-                    debug!("Connection to the peer {peer} exists.");
+                if let Some(evicted_worker) = workers.ensure_worker(
+                    peer,
+                    &endpoint,
+                    worker_channel_size,
+                    skip_check_transaction_age,
+                    max_reconnect_attempts,
+                    handshake_timeout,
+                    stats.clone(),
+                ) {
+                    shutdown_worker(evicted_worker);
                 }
             }
 


### PR DESCRIPTION
Rate-latency-tool uses it's own scheduler and lacks upstream scheduler changes: https://github.com/anza-xyz/agave/blob/master/tpu-client-next/src/connection_workers_scheduler.rs#L275