### PR TITLE
chore: Update to Rust 1.93

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.91.1"
+channel = "1.93.0"


### PR DESCRIPTION
Keeping this repo loosely in lockstep with Agave and internal Anza repos in terms of Rust compiler version.

Agave updated to Rust 1.92 in [PR 10234,](https://github.com/anza-xyz/agave/pull/10234) and 1.93 in [PR 10357](https://github.com/anza-xyz/agave/pull/10357).