### PR TITLE
chore: Format codebase in Rust 2024 edition style

### DIFF
--- a/rate-latency-tool/src/cli.rs
+++ b/rate-latency-tool/src/cli.rs
@@ -1,12 +1,12 @@
 pub use tools_common::cli::{AccountParams, LeaderTracker};
 use {
-    clap::{crate_description, crate_name, crate_version, value_parser, Args, Parser, Subcommand},
+    clap::{Args, Parser, Subcommand, crate_description, crate_name, crate_version, value_parser},
     solana_clap_v3_utils::input_parsers::parse_url,
     solana_commitment_config::CommitmentConfig,
     std::{net::SocketAddr, path::PathBuf},
     tokio::time::Duration,
     tools_common::cli::{
-        parse_and_normalize_url, parse_duration_ms, parse_duration_sec, ReadAccounts, WriteAccounts,
+        ReadAccounts, WriteAccounts, parse_and_normalize_url, parse_duration_ms, parse_duration_sec,
     },
 };
 

--- a/rate-latency-tool/src/main.rs
+++ b/rate-latency-tool/src/main.rs
@@ -4,7 +4,7 @@ use {
     solana_cli_config::ConfigInput,
     solana_keypair::Keypair,
     solana_rate_latency_tool::{
-        cli::{build_cli_parameters, ClientCliParameters, Command},
+        cli::{ClientCliParameters, Command, build_cli_parameters},
         error::RateLatencyToolError,
         run_client::run_client,
     },

--- a/rate-latency-tool/src/run_client.rs
+++ b/rate-latency-tool/src/run_client.rs
@@ -1,7 +1,7 @@
 use {
     crate::{
         cli::{ExecutionParams, TxAnalysisParams},
-        csv_writer::{run_csv_writer, CSVRecord},
+        csv_writer::{CSVRecord, run_csv_writer},
         error::RateLatencyToolError,
         run_rate_latency_tool_scheduler::run_rate_latency_tool_scheduler,
         yellowstone_subscriber::run_yellowstone_subscriber,
@@ -16,11 +16,11 @@ use {
     solana_signer::{EncodableKey, Signer},
     solana_time_utils::timestamp,
     solana_tpu_client_next::{
+        SendTransactionStats,
         connection_workers_scheduler::{
             BindTarget, ConnectionWorkersSchedulerConfig, Fanout, StakeIdentity,
         },
         node_address_service::LeaderTpuCacheServiceConfig,
-        SendTransactionStats,
     },
     solana_transaction::Transaction,
     std::{sync::Arc, time::Duration},

--- a/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
+++ b/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
@@ -4,10 +4,10 @@ use {
     solana_clock::Slot,
     solana_measure::measure::Measure,
     solana_tpu_client_next::{
-        connection_workers_scheduler::{setup_endpoint, ConnectionWorkersSchedulerConfig},
-        transaction_batch::TransactionBatch,
-        workers_cache::{shutdown_worker, spawn_worker, WorkersCache, WorkersCacheError},
         ConnectionWorkersSchedulerError, SendTransactionStats,
+        connection_workers_scheduler::{ConnectionWorkersSchedulerConfig, setup_endpoint},
+        transaction_batch::TransactionBatch,
+        workers_cache::{WorkersCache, WorkersCacheError, shutdown_worker, spawn_worker},
     },
     std::{sync::Arc, time::Duration},
     tokio::time::interval,

--- a/rate-latency-tool/src/yellowstone_subscriber.rs
+++ b/rate-latency-tool/src/yellowstone_subscriber.rs
@@ -25,10 +25,10 @@ use {
     },
     yellowstone_grpc_proto::{
         geyser::{
-            subscribe_update::UpdateOneof, CommitmentLevel, SlotStatus, SubscribeRequest,
-            SubscribeRequestFilterBlocksMeta, SubscribeRequestFilterEntry,
-            SubscribeRequestFilterSlots, SubscribeRequestFilterTransactions,
-            SubscribeUpdateTransaction,
+            CommitmentLevel, SlotStatus, SubscribeRequest, SubscribeRequestFilterBlocksMeta,
+            SubscribeRequestFilterEntry, SubscribeRequestFilterSlots,
+            SubscribeRequestFilterTransactions, SubscribeUpdateTransaction,
+            subscribe_update::UpdateOneof,
         },
         tonic::transport::Certificate,
     },

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,4 @@
 imports_granularity = "One"
 format_strings = true
 group_imports = "One"
+style_edition = "2024"

--- a/tools-common/src/accounts_creator.rs
+++ b/tools-common/src/accounts_creator.rs
@@ -2,7 +2,7 @@
 //! Using RpcClient for simplicity.
 #![allow(clippy::arithmetic_side_effects)]
 use {
-    crate::accounts_file::{write_accounts_file, AccountsFile},
+    crate::accounts_file::{AccountsFile, write_accounts_file},
     chrono::prelude::Utc,
     futures::future::join_all,
     log::*,
@@ -19,7 +19,7 @@ use {
     solana_transaction::Transaction,
     std::{path::PathBuf, sync::Arc},
     thiserror::Error,
-    tokio::time::{sleep, Duration},
+    tokio::time::{Duration, sleep},
 };
 
 /// How many transactions send concurrently.
@@ -301,7 +301,7 @@ mod tests {
     use {
         super::*,
         async_trait::async_trait,
-        rand::{rngs::StdRng, Rng, SeedableRng},
+        rand::{Rng, SeedableRng, rngs::StdRng},
         solana_keypair::Keypair,
         solana_rpc_client::{
             mock_sender::MockSender,

--- a/tools-common/src/leader_updater.rs
+++ b/tools-common/src/leader_updater.rs
@@ -7,7 +7,7 @@ use {
     },
     async_trait::async_trait,
     log::{debug, error},
-    solana_clock::{Slot, NUM_CONSECUTIVE_LEADER_SLOTS},
+    solana_clock::{NUM_CONSECUTIVE_LEADER_SLOTS, Slot},
     solana_connection_cache::connection_cache::Protocol,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_tpu_client::nonblocking::tpu_client::LeaderTpuService,
@@ -21,8 +21,8 @@ use {
     std::{
         net::SocketAddr,
         sync::{
-            atomic::{AtomicBool, Ordering},
             Arc,
+            atomic::{AtomicBool, Ordering},
         },
     },
     thiserror::Error,

--- a/tpu-client-next-extensions/src/yellowstone_leader_tracker.rs
+++ b/tpu-client-next-extensions/src/yellowstone_leader_tracker.rs
@@ -13,15 +13,15 @@ use {
     thiserror::Error,
     tokio::fs,
     tokio_util::sync::CancellationToken,
-    tonic::{async_trait, Status},
+    tonic::{Status, async_trait},
     yellowstone_grpc_client::{
         ClientTlsConfig, GeyserGrpcBuilderError, GeyserGrpcClient, GeyserGrpcClientError,
         Interceptor,
     },
     yellowstone_grpc_proto::{
         geyser::{
-            subscribe_update::UpdateOneof, CommitmentLevel, SlotStatus, SubscribeRequest,
-            SubscribeRequestFilterSlots, SubscribeUpdate, SubscribeUpdateSlot,
+            CommitmentLevel, SlotStatus, SubscribeRequest, SubscribeRequestFilterSlots,
+            SubscribeUpdate, SubscribeUpdateSlot, subscribe_update::UpdateOneof,
         },
         tonic::transport::Certificate,
     },

--- a/transaction-bench/src/backpressured_broadcaster.rs
+++ b/transaction-bench/src/backpressured_broadcaster.rs
@@ -5,10 +5,10 @@ use {
     async_trait::async_trait,
     log::{debug, warn},
     solana_tpu_client_next::{
+        ConnectionWorkersSchedulerError,
         connection_workers_scheduler::WorkersBroadcaster,
         transaction_batch::TransactionBatch,
-        workers_cache::{shutdown_worker, WorkersCache, WorkersCacheError},
-        ConnectionWorkersSchedulerError,
+        workers_cache::{WorkersCache, WorkersCacheError, shutdown_worker},
     },
     std::net::SocketAddr,
 };

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -1,5 +1,5 @@
 use {
-    clap::{crate_description, crate_name, crate_version, value_parser, Args, Parser, Subcommand},
+    clap::{Args, Parser, Subcommand, crate_description, crate_name, crate_version, value_parser},
     solana_clap_v3_utils::{
         input_parsers::parse_url_or_moniker, input_validators::normalize_to_url_if_moniker,
     },

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -12,16 +12,16 @@ use {
     solana_signer::{EncodableKey, Signer},
     solana_streamer::nonblocking::quic::ConnectionPeerType,
     solana_tpu_client_next::{
+        ConnectionWorkersScheduler,
         connection_workers_scheduler::{
             BindTarget, ConnectionWorkersSchedulerConfig, Fanout, StakeIdentity,
         },
         node_address_service::LeaderTpuCacheServiceConfig,
-        ConnectionWorkersScheduler,
     },
     solana_transaction_bench::{
         backpressured_broadcaster::BackpressuredBroadcaster,
         cli::{
-            build_cli_parameters, ClientCliParameters, Command, ExecutionParams, TransactionParams,
+            ClientCliParameters, Command, ExecutionParams, TransactionParams, build_cli_parameters,
         },
         error::BenchClientError,
         generator::TransactionGenerator,
@@ -34,8 +34,8 @@ use {
     tokio_util::sync::CancellationToken,
     tools_common::{
         accounts_file::{
-            create_ephemeral_accounts, create_file_persisted_accounts, read_accounts_file,
-            AccountsFile,
+            AccountsFile, create_ephemeral_accounts, create_file_persisted_accounts,
+            read_accounts_file,
         },
         blockhash_updater::BlockhashUpdater,
         leader_updater::create_leader_updater,


### PR DESCRIPTION
Update this repo to Rust 2024 edition formatting style. It's all in crate imports and capitalized names listed before lower case names.