### PR TITLE
chore: Fix lint warning for manual op check

### DIFF
--- a/tools-common/src/accounts_creator.rs
+++ b/tools-common/src/accounts_creator.rs
@@ -225,11 +225,9 @@ fn calculate_batch_size(
     num_created_accounts: usize,
     num_send_batch_attempts: usize,
 ) -> usize {
-    let mean_num_success = if num_send_batch_attempts == 0 {
-        std::cmp::min(num_accounts, MAX_RPC_SEND_TX_BATCH)
-    } else {
-        num_created_accounts / num_send_batch_attempts
-    };
+    let mean_num_success = num_created_accounts
+        .checked_div(num_send_batch_attempts)
+        .unwrap_or(std::cmp::min(num_accounts, MAX_RPC_SEND_TX_BATCH));
 
     std::cmp::min(mean_num_success + 1, num_accounts - num_created_accounts)
 }


### PR DESCRIPTION
### Problem
Running clippy gives the following error.
> warning: manual checked division
   --> tools-common/src/accounts_creator.rs:228:31
    |
228 |     let mean_num_success = if num_send_batch_attempts == 0 {
    |                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ check performed here
...
231 |         num_created_accounts / num_send_batch_attempts
    |         ---------------------------------------------- division performed here
    |
    = help: consider using `checked_div`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_checked_ops
    = note: `-D clippy::manual-checked-ops` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::manual_checked_ops)]`

### Solution
Use checked_div() to resolve the warning.