### PR TITLE
Pin solana-hash and solana-system-system-interface versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ solana-epoch-info = "3.0.0"
 solana-epoch-schedule = "3.0.0"
 solana-faucet = { git = "https://github.com/anza-xyz/agave.git", rev = "1088d29ee4da0f04df71cb8f286667693412e43f", features = ["agave-unstable-api"] }
 solana-fee-calculator = "3.0.0"
-solana-hash = "3.1.0"
+solana-hash = "=3.1.0"
 solana-instruction = "3.0.0"
 solana-keypair = "3.0.1"
 solana-logger = "3.0.0"
@@ -82,7 +82,7 @@ solana-sha256-hasher = "3.0.1"
 solana-signature = { version = "3.1.0" }
 solana-signer = "3.0.0"
 solana-streamer = { git = "https://github.com/anza-xyz/agave.git", rev = "1088d29ee4da0f04df71cb8f286667693412e43f", features = ["agave-unstable-api"] }
-solana-system-interface = "2.0"
+solana-system-interface = "=2.0"
 solana-test-validator = { git = "https://github.com/anza-xyz/agave.git", rev = "1088d29ee4da0f04df71cb8f286667693412e43f", features = ["agave-unstable-api"] }
 solana-time-utils = "3.0.0"
 solana-tpu-client = { git = "https://github.com/anza-xyz/agave.git", rev = "1088d29ee4da0f04df71cb8f286667693412e43f", features = ["agave-unstable-api"] }


### PR DESCRIPTION
### Problem
solana-hash and solana-system-system-interface crate versions need to match between Agave and yellowstone geyser plugin.

### Solution
Pin the versions to avoid accidental upgrade from dependabot PRs.