### PR TITLE
transaction-bench: add support of instruction padding like in bench-tps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9933,7 +9933,9 @@ dependencies = [
  "solana-test-validator",
  "solana-time-utils",
  "solana-tpu-client-next",
+ "solana-transaction 3.1.0",
  "solana-transaction 4.0.0",
+ "spl-instruction-padding-interface",
  "thiserror 2.0.18",
  "tikv-jemallocator",
  "tokio",
@@ -10444,6 +10446,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233df81b75ab99b42f002b5cdd6e65a7505ffa930624f7096a7580a56765e9cf"
 dependencies = [
  "bytemuck",
+ "solana-pubkey 3.0.0",
+]
+
+[[package]]
+name = "spl-instruction-padding-interface"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3a77c0c9b83b111ee29bc6aa6eaab54b82e1ed5db40ba9786527b80283c3ef"
+dependencies = [
+ "num_enum",
+ "solana-instruction",
+ "solana-program-error",
  "solana-pubkey 3.0.0",
 ]
 

--- a/transaction-bench/Cargo.toml
+++ b/transaction-bench/Cargo.toml
@@ -48,6 +48,7 @@ solana-system-interface = { workspace = true }
 solana-time-utils = { workspace = true }
 solana-tpu-client-next = { workspace = true }
 solana-transaction = { workspace = true }
+spl-instruction-padding-interface = "=1.0.0"
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/transaction-bench/Cargo.toml
+++ b/transaction-bench/Cargo.toml
@@ -65,6 +65,7 @@ solana-pubsub-client = { workspace = true }
 solana-rpc = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 solana-test-validator = { workspace = true }
+solana-transaction-3 = { workspace = true }
 
 [lints]
 workspace = true

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -4,6 +4,7 @@ use {
         input_parsers::parse_url_or_moniker, input_validators::normalize_to_url_if_moniker,
     },
     solana_commitment_config::CommitmentConfig,
+    solana_pubkey::Pubkey,
     std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf},
     tokio::time::Duration,
     tools_common::cli::{AccountParams, LeaderTracker, ReadAccounts, WriteAccounts},
@@ -147,6 +148,26 @@ pub struct TransactionParams {
     //TODO(klykov): memo
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct InstructionPaddingConfig {
+    pub program_id: Pubkey,
+    pub data_size: u32,
+}
+
+impl TransactionParams {
+    pub fn instruction_padding_config(&self) -> Option<InstructionPaddingConfig> {
+        self.simple_transfer_tx_params
+            .instruction_padding_data_size
+            .map(|data_size| InstructionPaddingConfig {
+                program_id: self
+                    .simple_transfer_tx_params
+                    .instruction_padding_program_id
+                    .unwrap_or(spl_instruction_padding_interface::ID),
+                data_size,
+            })
+    }
+}
+
 #[derive(Args, Clone, Debug, PartialEq, Eq)]
 #[clap(rename_all = "kebab-case")]
 pub struct SimpleTransferTxParams {
@@ -168,6 +189,21 @@ pub struct SimpleTransferTxParams {
         help = "Number of send instructions per transaction."
     )]
     pub num_send_instructions_per_tx: usize,
+
+    #[clap(
+        long,
+        help = "If set, wraps all transfer instructions in the instruction padding program, with \
+                the given amount of padding bytes in instruction data."
+    )]
+    pub instruction_padding_data_size: Option<u32>,
+
+    #[clap(
+        long,
+        requires = "instruction_padding_data_size",
+        help = "Optionally specify the instruction padding program id. Defaults to the SPL \
+                instruction padding program."
+    )]
+    pub instruction_padding_program_id: Option<Pubkey>,
 
     #[clap(
         long,
@@ -274,6 +310,8 @@ mod tests {
                         lamports_to_transfer: 1000,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
+                        instruction_padding_data_size: None,
+                        instruction_padding_program_id: None,
                         tx_batch_size: None,
                         num_conflict_groups: None,
                     },
@@ -323,6 +361,8 @@ mod tests {
                         lamports_to_transfer: 513,
                         transfer_tx_cu_budget: 1000,
                         num_send_instructions_per_tx: 2,
+                        instruction_padding_data_size: None,
+                        instruction_padding_program_id: None,
                         tx_batch_size: None,
                         num_conflict_groups: None,
                     },
@@ -337,6 +377,26 @@ mod tests {
         let actual = cli.unwrap();
 
         assert_eq!(actual, expected_parameters);
+    }
+
+    #[test]
+    fn test_instruction_padding_config_defaults_program_id() {
+        let params = TransactionParams {
+            simple_transfer_tx_params: SimpleTransferTxParams {
+                lamports_to_transfer: 513,
+                transfer_tx_cu_budget: 600,
+                num_send_instructions_per_tx: 1,
+                instruction_padding_data_size: Some(128),
+                instruction_padding_program_id: None,
+                tx_batch_size: None,
+                num_conflict_groups: None,
+            },
+        };
+
+        let padding_config = params.instruction_padding_config().unwrap();
+
+        assert_eq!(padding_config.program_id, spl_instruction_padding_interface::ID);
+        assert_eq!(padding_config.data_size, 128);
     }
 
     #[test]

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -420,7 +420,10 @@ mod tests {
 
         let padding_config = params.instruction_padding_config().unwrap();
 
-        assert_eq!(padding_config.program_id, spl_instruction_padding_interface::ID);
+        assert_eq!(
+            padding_config.program_id,
+            spl_instruction_padding_interface::ID
+        );
         assert_eq!(padding_config.data_size, 128);
         assert_eq!(padding_config.loaded_accounts_data_size_limit, 58 * 1024);
     }

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -145,25 +145,59 @@ pub struct ExecutionParams {
 pub struct TransactionParams {
     #[clap(flatten)]
     pub simple_transfer_tx_params: SimpleTransferTxParams,
+
+    #[clap(flatten)]
+    pub padding_params: InstructionPaddingParams,
     //TODO(klykov): memo
+}
+
+#[derive(Args, Clone, Debug, PartialEq, Eq)]
+#[clap(rename_all = "kebab-case")]
+pub struct InstructionPaddingParams {
+    #[clap(
+        long,
+        help = "If set, wraps all transfer instructions in the instruction padding program, with \
+                the given amount of padding bytes in instruction data."
+    )]
+    pub instruction_padding_data_size: Option<u32>,
+
+    #[clap(
+        long,
+        requires = "instruction_padding_data_size",
+        help = "Optionally specify the instruction padding program id. Defaults to the SPL \
+                instruction padding program."
+    )]
+    pub instruction_padding_program_id: Option<Pubkey>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct InstructionPaddingConfig {
     pub program_id: Pubkey,
     pub data_size: u32,
+    pub loaded_accounts_data_size_limit: u32,
+}
+
+// In case of plain transfer transaction, set loaded account data size to 30 KiB.
+// It is large enough yet smaller than 32 KiB page size, so it would cost 0 extra CU.
+const TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE: u32 = 30 * 1024;
+// In case of padding program usage, we need to take into account program size too.
+const PADDING_PROGRAM_ACCOUNT_DATA_SIZE: u32 = 28 * 1024;
+
+fn get_padded_transaction_loaded_accounts_data_size() -> u32 {
+    TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE + PADDING_PROGRAM_ACCOUNT_DATA_SIZE
 }
 
 impl TransactionParams {
     pub fn instruction_padding_config(&self) -> Option<InstructionPaddingConfig> {
-        self.simple_transfer_tx_params
+        self.padding_params
             .instruction_padding_data_size
             .map(|data_size| InstructionPaddingConfig {
                 program_id: self
-                    .simple_transfer_tx_params
+                    .padding_params
                     .instruction_padding_program_id
                     .unwrap_or(spl_instruction_padding_interface::ID),
                 data_size,
+                loaded_accounts_data_size_limit: get_padded_transaction_loaded_accounts_data_size(),
             })
     }
 }
@@ -189,21 +223,6 @@ pub struct SimpleTransferTxParams {
         help = "Number of send instructions per transaction."
     )]
     pub num_send_instructions_per_tx: usize,
-
-    #[clap(
-        long,
-        help = "If set, wraps all transfer instructions in the instruction padding program, with \
-                the given amount of padding bytes in instruction data."
-    )]
-    pub instruction_padding_data_size: Option<u32>,
-
-    #[clap(
-        long,
-        requires = "instruction_padding_data_size",
-        help = "Optionally specify the instruction padding program id. Defaults to the SPL \
-                instruction padding program."
-    )]
-    pub instruction_padding_program_id: Option<Pubkey>,
 
     #[clap(
         long,
@@ -310,10 +329,12 @@ mod tests {
                         lamports_to_transfer: 1000,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
-                        instruction_padding_data_size: None,
-                        instruction_padding_program_id: None,
                         tx_batch_size: None,
                         num_conflict_groups: None,
+                    },
+                    padding_params: InstructionPaddingParams {
+                        instruction_padding_data_size: None,
+                        instruction_padding_program_id: None,
                     },
                 },
                 account_params,
@@ -361,10 +382,12 @@ mod tests {
                         lamports_to_transfer: 513,
                         transfer_tx_cu_budget: 1000,
                         num_send_instructions_per_tx: 2,
-                        instruction_padding_data_size: None,
-                        instruction_padding_program_id: None,
                         tx_batch_size: None,
                         num_conflict_groups: None,
+                    },
+                    padding_params: InstructionPaddingParams {
+                        instruction_padding_data_size: None,
+                        instruction_padding_program_id: None,
                     },
                 },
                 execution_params,
@@ -386,10 +409,12 @@ mod tests {
                 lamports_to_transfer: 513,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx: 1,
-                instruction_padding_data_size: Some(128),
-                instruction_padding_program_id: None,
                 tx_batch_size: None,
                 num_conflict_groups: None,
+            },
+            padding_params: InstructionPaddingParams {
+                instruction_padding_data_size: Some(128),
+                instruction_padding_program_id: None,
             },
         };
 
@@ -397,6 +422,7 @@ mod tests {
 
         assert_eq!(padding_config.program_id, spl_instruction_padding_interface::ID);
         assert_eq!(padding_config.data_size, 128);
+        assert_eq!(padding_config.loaded_accounts_data_size_limit, 58 * 1024);
     }
 
     #[test]

--- a/transaction-bench/src/generator/simple_transfers_generator.rs
+++ b/transaction-bench/src/generator/simple_transfers_generator.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
-        cli::SimpleTransferTxParams, generator::transaction_builder::create_serialized_transfers,
+        cli::{InstructionPaddingConfig, SimpleTransferTxParams},
+        generator::transaction_builder::create_serialized_transfers,
     },
     log::debug,
     rand::{seq::IteratorRandom, thread_rng},
@@ -21,6 +22,8 @@ pub(crate) fn generate_transfer_transaction_batch(
         lamports_to_transfer,
         transfer_tx_cu_budget,
         num_send_instructions_per_tx,
+        instruction_padding_data_size,
+        instruction_padding_program_id,
         num_conflict_groups,
         ..
     }: SimpleTransferTxParams,
@@ -28,6 +31,12 @@ pub(crate) fn generate_transfer_transaction_batch(
 ) -> JoinHandle<Vec<Vec<u8>>> {
     spawn_blocking_transaction_batch_generation("generate transfer transaction batch", move || {
         let mut txs: Vec<Vec<u8>> = Vec::with_capacity(send_batch_size);
+        let instruction_padding_config =
+            instruction_padding_data_size.map(|data_size| InstructionPaddingConfig {
+                program_id: instruction_padding_program_id
+                    .unwrap_or(spl_instruction_padding_interface::ID),
+                data_size,
+            });
 
         let total_pairs = num_send_instructions_per_tx * send_batch_size;
 
@@ -51,6 +60,7 @@ pub(crate) fn generate_transfer_transaction_batch(
                 &mut signers,
                 num_send_instructions_per_tx,
                 transfer_tx_cu_budget,
+                instruction_padding_config.as_ref(),
             );
             txs.push(tx);
             instructions.clear();

--- a/transaction-bench/src/generator/simple_transfers_generator.rs
+++ b/transaction-bench/src/generator/simple_transfers_generator.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        cli::{InstructionPaddingConfig, SimpleTransferTxParams},
+        cli::TransactionParams,
         generator::transaction_builder::create_serialized_transfers,
     },
     log::debug,
@@ -18,25 +18,24 @@ pub(crate) fn generate_transfer_transaction_batch(
     payers: Arc<Vec<Keypair>>,
     payer_index: usize,
     blockhash: Hash,
-    SimpleTransferTxParams {
-        lamports_to_transfer,
-        transfer_tx_cu_budget,
-        num_send_instructions_per_tx,
-        instruction_padding_data_size,
-        instruction_padding_program_id,
-        num_conflict_groups,
-        ..
-    }: SimpleTransferTxParams,
+    TransactionParams {
+        simple_transfer_tx_params,
+        padding_params,
+    }: TransactionParams,
     send_batch_size: usize,
 ) -> JoinHandle<Vec<Vec<u8>>> {
     spawn_blocking_transaction_batch_generation("generate transfer transaction batch", move || {
         let mut txs: Vec<Vec<u8>> = Vec::with_capacity(send_batch_size);
-        let instruction_padding_config =
-            instruction_padding_data_size.map(|data_size| InstructionPaddingConfig {
-                program_id: instruction_padding_program_id
-                    .unwrap_or(spl_instruction_padding_interface::ID),
-                data_size,
-            });
+        let instruction_padding_config = TransactionParams {
+            simple_transfer_tx_params: simple_transfer_tx_params.clone(),
+            padding_params: padding_params.clone(),
+        }
+        .instruction_padding_config();
+
+        let lamports_to_transfer = simple_transfer_tx_params.lamports_to_transfer;
+        let transfer_tx_cu_budget = simple_transfer_tx_params.transfer_tx_cu_budget;
+        let num_send_instructions_per_tx = simple_transfer_tx_params.num_send_instructions_per_tx;
+        let num_conflict_groups = simple_transfer_tx_params.num_conflict_groups;
 
         let total_pairs = num_send_instructions_per_tx * send_batch_size;
 

--- a/transaction-bench/src/generator/simple_transfers_generator.rs
+++ b/transaction-bench/src/generator/simple_transfers_generator.rs
@@ -1,8 +1,5 @@
 use {
-    crate::{
-        cli::TransactionParams,
-        generator::transaction_builder::create_serialized_transfers,
-    },
+    crate::{cli::TransactionParams, generator::transaction_builder::create_serialized_transfers},
     log::debug,
     rand::{seq::IteratorRandom, thread_rng},
     solana_hash::Hash,

--- a/transaction-bench/src/generator/transaction_builder.rs
+++ b/transaction-bench/src/generator/transaction_builder.rs
@@ -1,7 +1,9 @@
 use {
+    crate::cli::InstructionPaddingConfig,
     solana_compute_budget_interface::ComputeBudgetInstruction, solana_hash::Hash,
     solana_instruction::Instruction, solana_keypair::Keypair, solana_signer::Signer,
     solana_system_interface::instruction as system_instruction, solana_transaction::Transaction,
+    spl_instruction_padding_interface::instruction::wrap_instruction,
 };
 
 #[allow(dead_code)]
@@ -40,6 +42,7 @@ pub(crate) fn create_serialized_transfers<'a, S, R, L>(
     signers: &mut Vec<&'a Keypair>,
     num_send_instructions_per_tx: usize,
     transaction_cu_budget: u32,
+    instruction_padding_config: Option<&InstructionPaddingConfig>,
 ) -> Vec<u8>
 where
     S: Iterator<Item = &'a Keypair>,
@@ -58,10 +61,14 @@ where
 
     // First transfer: account-from = tx_payer_kp, account-to from iterator
     let receiver = accounts_to.next().unwrap();
-    instructions.push(system_instruction::transfer(
+    let transfer_instruction = system_instruction::transfer(
         tx_payer,
         &receiver.pubkey(),
         *lamports.next().unwrap(),
+    );
+    instructions.push(maybe_wrap_instruction(
+        transfer_instruction,
+        instruction_padding_config,
     ));
 
     // Additional transfers for multi-instruction transactions
@@ -72,10 +79,14 @@ where
         .take(num_send_instructions_per_tx.saturating_sub(1))
     {
         signers.push(sender);
-        instructions.push(system_instruction::transfer(
+        let transfer_instruction = system_instruction::transfer(
             &sender.pubkey(),
             &receiver.pubkey(),
             *amount,
+        );
+        instructions.push(maybe_wrap_instruction(
+            transfer_instruction,
+            instruction_padding_config,
         ));
     }
 
@@ -83,4 +94,56 @@ where
         Transaction::new_signed_with_payer(instructions, Some(tx_payer), signers, recent_blockhash);
 
     wincode::serialize(&tx).expect("serialize Transaction in send_batch")
+}
+
+fn maybe_wrap_instruction(
+    instruction: Instruction,
+    instruction_padding_config: Option<&InstructionPaddingConfig>,
+) -> Instruction {
+    match instruction_padding_config {
+        Some(padding_config) => wrap_instruction(
+            padding_config.program_id,
+            instruction,
+            vec![],
+            padding_config.data_size,
+        )
+        .expect("Could not create padded instruction"),
+        None => instruction,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_pubkey::Pubkey,
+    };
+
+    #[test]
+    fn test_maybe_wrap_instruction_keeps_transfer_when_disabled() {
+        let from = Pubkey::new_unique();
+        let to = Pubkey::new_unique();
+        let transfer_instruction = system_instruction::transfer(&from, &to, 1);
+
+        let instruction = maybe_wrap_instruction(transfer_instruction.clone(), None);
+
+        assert_eq!(instruction, transfer_instruction);
+    }
+
+    #[test]
+    fn test_maybe_wrap_instruction_uses_padding_program_when_enabled() {
+        let from = Pubkey::new_unique();
+        let to = Pubkey::new_unique();
+        let transfer_instruction = system_instruction::transfer(&from, &to, 1);
+        let padding_program_id = Pubkey::new_unique();
+        let padding_config = InstructionPaddingConfig {
+            program_id: padding_program_id,
+            data_size: 64,
+        };
+
+        let instruction = maybe_wrap_instruction(transfer_instruction, Some(&padding_config));
+
+        assert_eq!(instruction.program_id, padding_program_id);
+        assert!(!instruction.data.is_empty());
+    }
 }

--- a/transaction-bench/src/generator/transaction_builder.rs
+++ b/transaction-bench/src/generator/transaction_builder.rs
@@ -70,11 +70,8 @@ where
 
     // First transfer: account-from = tx_payer_kp, account-to from iterator
     let receiver = accounts_to.next().unwrap();
-    let transfer_instruction = system_instruction::transfer(
-        tx_payer,
-        &receiver.pubkey(),
-        *lamports.next().unwrap(),
-    );
+    let transfer_instruction =
+        system_instruction::transfer(tx_payer, &receiver.pubkey(), *lamports.next().unwrap());
     instructions.push(maybe_wrap_instruction(
         transfer_instruction,
         instruction_padding_config,
@@ -88,11 +85,8 @@ where
         .take(num_send_instructions_per_tx.saturating_sub(1))
     {
         signers.push(sender);
-        let transfer_instruction = system_instruction::transfer(
-            &sender.pubkey(),
-            &receiver.pubkey(),
-            *amount,
-        );
+        let transfer_instruction =
+            system_instruction::transfer(&sender.pubkey(), &receiver.pubkey(), *amount);
         instructions.push(maybe_wrap_instruction(
             transfer_instruction,
             instruction_padding_config,
@@ -123,10 +117,7 @@ fn maybe_wrap_instruction(
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-        solana_pubkey::Pubkey,
-    };
+    use {super::*, solana_pubkey::Pubkey};
 
     #[test]
     fn test_maybe_wrap_instruction_keeps_transfer_when_disabled() {

--- a/transaction-bench/src/generator/transaction_builder.rs
+++ b/transaction-bench/src/generator/transaction_builder.rs
@@ -49,6 +49,15 @@ where
     R: Iterator<Item = &'a Keypair>,
     L: Iterator<Item = &'a u64>,
 {
+    if let Some(padding_config) = instruction_padding_config {
+        instructions.insert(
+            0,
+            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
+                padding_config.loaded_accounts_data_size_limit,
+            ),
+        );
+    }
+
     instructions.insert(
         0,
         ComputeBudgetInstruction::set_compute_unit_limit(transaction_cu_budget),
@@ -139,6 +148,7 @@ mod tests {
         let padding_config = InstructionPaddingConfig {
             program_id: padding_program_id,
             data_size: 64,
+            loaded_accounts_data_size_limit: 58 * 1024,
         };
 
         let instruction = maybe_wrap_instruction(transfer_instruction, Some(&padding_config));

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -20,6 +20,7 @@ use {
 
 const COMPUTE_BUDGET_INSTRUCTION_CU_COST: u32 = 150;
 const SIMPLE_TRANSFER_INSTRUCTION_CU_COST: u32 = 150;
+const PADDED_TRANSFER_INSTRUCTION_CU_COST: u32 = 3_000;
 
 #[derive(Error, Debug)]
 pub enum TransactionGeneratorError {
@@ -74,11 +75,17 @@ impl TransactionGenerator {
         let &SimpleTransferTxParams {
             num_send_instructions_per_tx,
             transfer_tx_cu_budget,
+            instruction_padding_data_size,
             ..
         } = &self.transaction_params.simple_transfer_tx_params;
 
+        let per_instruction_cu_cost = if instruction_padding_data_size.is_some() {
+            PADDED_TRANSFER_INSTRUCTION_CU_COST
+        } else {
+            SIMPLE_TRANSFER_INSTRUCTION_CU_COST
+        };
         let transfer_tx_min_cu_budget = COMPUTE_BUDGET_INSTRUCTION_CU_COST
-            + SIMPLE_TRANSFER_INSTRUCTION_CU_COST * num_send_instructions_per_tx as u32;
+            + per_instruction_cu_cost * num_send_instructions_per_tx as u32;
 
         if transfer_tx_cu_budget < transfer_tx_min_cu_budget {
             error!(

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -95,7 +95,7 @@ impl TransactionGenerator {
             error!(
                 "Insufficient CU budget for transfer transaction: set to {transfer_tx_cu_budget}, \
                  need at least {transfer_tx_min_cu_budget}.\nSet cli argument \
-                 --transfer_tx_cu_budget to {transfer_tx_min_cu_budget}",
+                 --transfer-tx-cu-budget to {transfer_tx_min_cu_budget}",
             );
             return Err(TransactionGeneratorError::GenerateTxBatchFailure);
         }

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -75,11 +75,15 @@ impl TransactionGenerator {
         let &SimpleTransferTxParams {
             num_send_instructions_per_tx,
             transfer_tx_cu_budget,
-            instruction_padding_data_size,
             ..
         } = &self.transaction_params.simple_transfer_tx_params;
 
-        let per_instruction_cu_cost = if instruction_padding_data_size.is_some() {
+        let per_instruction_cu_cost = if self
+            .transaction_params
+            .padding_params
+            .instruction_padding_data_size
+            .is_some()
+        {
             PADDED_TRANSFER_INSTRUCTION_CU_COST
         } else {
             SIMPLE_TRANSFER_INSTRUCTION_CU_COST
@@ -133,7 +137,7 @@ impl TransactionGenerator {
                                 payers,
                                 index_payer,
                                 blockhash,
-                                transaction_params.simple_transfer_tx_params,
+                                transaction_params,
                                 send_batch_size,
                             )
                             .await

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -182,6 +182,22 @@ pub async fn run_client(
         }
     }
 
+    if let Some(instruction_padding_config) = transaction_params.instruction_padding_config() {
+        info!(
+            "Checking for existence of instruction padding program: {}",
+            instruction_padding_config.program_id
+        );
+        rpc_client
+            .get_account(&instruction_padding_config.program_id)
+            .await
+            .map_err(|err| {
+                BenchClientError::InvalidCliArguments(format!(
+                    "instruction padding program {} is not available: {err}",
+                    instruction_padding_config.program_id
+                ))
+            })?;
+    }
+
     let blockhash = rpc_client
         .get_latest_blockhash()
         .await

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -17,9 +17,11 @@ use {
     solana_sdk_ids::system_program,
     solana_signer::Signer,
     solana_test_validator::TestValidatorGenesis,
-    solana_transaction::versioned::VersionedTransaction,
+    solana_transaction_3::versioned::VersionedTransaction,
     solana_transaction_bench::{
-        cli::{ExecutionParams, SimpleTransferTxParams, TransactionParams},
+        cli::{
+            ExecutionParams, InstructionPaddingParams, SimpleTransferTxParams, TransactionParams,
+        },
         run_client::run_client,
     },
     std::{
@@ -121,6 +123,10 @@ fn test_transactions_sending() {
                     num_send_instructions_per_tx: 1,
                     tx_batch_size: None,
                     num_conflict_groups: None,
+                },
+                padding_params: InstructionPaddingParams {
+                    instruction_padding_data_size: None,
+                    instruction_padding_program_id: None,
                 },
             },
             ExecutionParams {


### PR DESCRIPTION
Summary
- add optional instruction padding support to transaction-bench
- add CLI options for instruction padding data size and padding program id
- wrap transfer instructions with the SPL instruction padding program when enabled
- validate that the padding program exists before starting the run
- preserve the simple-transfer path when padding is disabled


Part of #40
