### PR TITLE
transaction-bench: add `--target-tps` cla

### DIFF
--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -4,7 +4,6 @@ use {
         input_parsers::parse_url_or_moniker, input_validators::normalize_to_url_if_moniker,
     },
     solana_commitment_config::CommitmentConfig,
-    solana_pubkey::Pubkey,
     std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf},
     tokio::time::Duration,
     tools_common::cli::{AccountParams, LeaderTracker, ReadAccounts, WriteAccounts},
@@ -109,6 +108,14 @@ pub struct ExecutionParams {
         help = "If specified, limits the benchmark execution to the specified duration."
     )]
     pub duration: Option<Duration>,
+
+    #[clap(
+        long,
+        value_parser = value_parser!(NonZeroU64),
+        help = "Optional global target send rate in transactions per second. When set, \
+                transaction-bench switches to paced sending."
+    )]
+    pub target_tps: Option<NonZeroU64>,
 
     #[clap(
         long,
@@ -289,6 +296,7 @@ mod tests {
                 staked_identity_file: Some(PathBuf::from(&keypair_file_name)),
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
                 duration: Some(Duration::from_secs(120)),
+                target_tps: None,
                 leader_tracker: LeaderTracker::PinnedLeaderTracker {
                     address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8009),
                 },
@@ -428,6 +436,42 @@ mod tests {
         assert_eq!(padding_config.loaded_accounts_data_size_limit, 58 * 1024);
     }
 
+    #[test]
+    fn test_target_tps_execution_param() {
+        let keypair_file_name = "/home/testUser/masterKey.json";
+
+        let mut args = vec![
+            "test",
+            "-ul",
+            "--authority",
+            keypair_file_name,
+            "run",
+            "--lamports-to-transfer",
+            "1000",
+            "--transfer-tx-cu-budget",
+            "600",
+            "--target-tps",
+            "100",
+        ];
+        let (account_args, account_params) = get_common_account_params();
+        args.extend(account_args.iter());
+        let (exec_args, mut execution_params) = get_common_execution_params(keypair_file_name);
+        args.extend(exec_args.iter());
+        execution_params.target_tps = Some(NonZeroU64::new(100).unwrap());
+
+        let actual = ClientCliParameters::try_parse_from(args).unwrap();
+        let Command::Run {
+            account_params: actual_account_params,
+            execution_params: actual_execution_params,
+            ..
+        } = actual.command
+        else {
+            panic!("expected run command");
+        };
+
+        assert_eq!(actual_account_params, account_params);
+        assert_eq!(actual_execution_params, execution_params);
+    }
     #[test]
     fn test_write_accounts_command() {
         let keypair_file_name = "/home/testUser/masterKey.json";

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -4,7 +4,12 @@ use {
         input_parsers::parse_url_or_moniker, input_validators::normalize_to_url_if_moniker,
     },
     solana_commitment_config::CommitmentConfig,
-    std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf},
+    solana_pubkey::Pubkey,
+    std::{
+        net::SocketAddr,
+        num::{NonZeroU64, NonZeroUsize},
+        path::PathBuf,
+    },
     tokio::time::Duration,
     tools_common::cli::{AccountParams, LeaderTracker, ReadAccounts, WriteAccounts},
 };

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -8,7 +8,7 @@ use {
     solana_hash::Hash,
     solana_measure::measure::Measure,
     solana_tpu_client_next::transaction_batch::TransactionBatch,
-    std::sync::Arc,
+    std::{num::NonZeroU64, sync::Arc},
     thiserror::Error,
     tokio::{
         sync::{mpsc::Sender, watch},
@@ -38,6 +38,7 @@ pub struct TransactionGenerator {
     transaction_params: TransactionParams,
     send_batch_size: usize,
     run_duration: Option<Duration>,
+    target_tps: Option<NonZeroU64>,
     workers_pull_size: usize,
 }
 
@@ -49,6 +50,7 @@ impl TransactionGenerator {
         transaction_params: TransactionParams,
         send_batch_size: usize,
         duration: Option<Duration>,
+        target_tps: Option<NonZeroU64>,
         workers_pull_size: usize,
     ) -> Self {
         Self {
@@ -58,6 +60,7 @@ impl TransactionGenerator {
             transaction_params,
             send_batch_size,
             run_duration: duration,
+            target_tps,
             workers_pull_size,
         }
     }
@@ -101,6 +104,7 @@ impl TransactionGenerator {
         }
 
         let start = Instant::now();
+        let mut next_batch_at = self.target_tps.map(|_| start);
         loop {
             if let Some(run_duration) = self.run_duration
                 && start.elapsed() >= run_duration
@@ -118,6 +122,9 @@ impl TransactionGenerator {
             let blockhash = *self.blockhash_receiver.borrow();
 
             while futures.len() < self.workers_pull_size {
+                if let Some(next_batch_deadline) = next_batch_at {
+                    tokio::time::sleep_until(next_batch_deadline).await;
+                }
                 let send_batch_size = self.send_batch_size;
                 let transaction_params = self.transaction_params.clone();
                 let payers = payers.clone();
@@ -158,6 +165,15 @@ impl TransactionGenerator {
                             % len_payers;
                     }
                 }
+
+                if let Some(target_tps) = self.target_tps {
+                    let batch_interval = compute_batch_interval(send_batch_size, target_tps);
+                    next_batch_at = Some(
+                        next_batch_at
+                            .map(|next_batch_deadline| next_batch_deadline + batch_interval)
+                            .unwrap_or_else(|| Instant::now() + batch_interval),
+                    );
+                }
             }
             futures.join_next().await;
         }
@@ -185,4 +201,29 @@ async fn send_batch(wired_txs_batch: Vec<Vec<u8>>, transactions_sender: Sender<T
         "Time to send into transactions queue: {} us",
         measure_send_to_queue.as_us()
     );
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn compute_batch_interval(send_batch_size: usize, target_tps: NonZeroU64) -> Duration {
+    let send_batch_size = u128::try_from(send_batch_size).unwrap_or(u128::MAX);
+    let target_tps = u128::from(target_tps.get());
+    let batch_interval_nanos = (send_batch_size * 1_000_000_000).div_ceil(target_tps);
+    Duration::from_nanos(u64::try_from(batch_interval_nanos).unwrap_or(u64::MAX))
+}
+
+#[cfg(test)]
+mod tests {
+    use {super::compute_batch_interval, std::num::NonZeroU64, tokio::time::Duration};
+
+    #[test]
+    fn test_compute_batch_interval() {
+        assert_eq!(
+            compute_batch_interval(10, NonZeroU64::new(100).unwrap()),
+            Duration::from_millis(100)
+        );
+        assert_eq!(
+            compute_batch_interval(1, NonZeroU64::new(1).unwrap()),
+            Duration::from_secs(1)
+        );
+    }
 }

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -22,7 +22,7 @@ use {
         },
         node_address_service::LeaderTpuCacheServiceConfig,
     },
-    std::{fmt::Debug, sync::Arc, time::Duration},
+    std::{fmt::Debug, num::NonZeroU64, sync::Arc, time::Duration},
     tokio::{
         sync::{mpsc, watch},
         task::JoinHandle,
@@ -49,6 +49,7 @@ const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(1);
 /// Default number of streams per connection if stake-based computation fails.
 /// This failure happens if we use stake overrides.
 const DEFAULT_NUM_STREAMS_PER_CONNECTION: usize = 8;
+const TARGET_BATCHES_PER_SECOND: u64 = 10;
 
 async fn find_node_activated_stake(
     rpc_client: &Arc<RpcClient>,
@@ -129,6 +130,7 @@ pub async fn run_client(
         staked_identity_file,
         bind,
         duration,
+        target_tps,
         num_max_open_connections,
         workers_pull_size,
         send_fanout,
@@ -157,10 +159,18 @@ pub async fn run_client(
         .simple_transfer_tx_params
         .tx_batch_size
         .map(|n| n.get());
-    let send_batch_size = tx_batch_size.unwrap_or(num_streams_per_connection);
+    let send_batch_size =
+        compute_send_batch_size(tx_batch_size, num_streams_per_connection, target_tps);
+    let workers_pull_size =
+        compute_workers_pull_size(workers_pull_size, send_batch_size, target_tps);
     info!("Number of streams per connection is {num_streams_per_connection}.");
     if let Some(tx_batch_size) = tx_batch_size {
         info!("Using tx batch size override: {tx_batch_size}.");
+    } else if let Some(target_tps) = target_tps {
+        info!("Using rate-limited tx batch size {send_batch_size} for target {target_tps} tx/s.");
+    }
+    if let Some(target_tps) = target_tps {
+        info!("Using {workers_pull_size} generator workers for target {target_tps} tx/s.");
     }
 
     if let Some(num_conflict_groups) = transaction_params
@@ -217,6 +227,7 @@ pub async fn run_client(
         transaction_params,
         send_batch_size,
         duration,
+        target_tps,
         workers_pull_size,
     );
 
@@ -275,6 +286,42 @@ pub async fn run_client(
     join_service(blockhash_task_handle, "BlockhashUpdater").await?;
     join_service(scheduler_handle, "Scheduler").await?;
     Ok(())
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn compute_send_batch_size(
+    tx_batch_size_override: Option<usize>,
+    num_streams_per_connection: usize,
+    target_tps: Option<NonZeroU64>,
+) -> usize {
+    tx_batch_size_override.unwrap_or_else(|| {
+        target_tps.map_or(num_streams_per_connection, |target_tps| {
+            let target_tps = target_tps.get();
+            let target_batch_size = target_tps.div_ceil(TARGET_BATCHES_PER_SECOND);
+            usize::try_from(target_batch_size)
+                .unwrap_or(usize::MAX)
+                .clamp(1, num_streams_per_connection)
+        })
+    })
+}
+
+#[allow(clippy::arithmetic_side_effects)]
+fn compute_workers_pull_size(
+    configured_workers_pull_size: usize,
+    send_batch_size: usize,
+    target_tps: Option<NonZeroU64>,
+) -> usize {
+    target_tps.map_or(configured_workers_pull_size, |target_tps| {
+        let target_batches_per_sec = target_tps
+            .get()
+            .div_ceil(u64::try_from(send_batch_size).unwrap_or(u64::MAX));
+        let guessed_workers = match target_batches_per_sec {
+            0..=1 => 1,
+            2..=10 => 2,
+            _ => 4,
+        };
+        guessed_workers.min(configured_workers_pull_size.max(1))
+    })
 }
 
 // Private function copied from streamer::nonblocking::swqos

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -133,6 +133,7 @@ fn test_transactions_sending() {
                 staked_identity_file: None,
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
                 duration: Some(Duration::from_secs(5)),
+                target_tps: None,
                 num_max_open_connections: 1,
                 workers_pull_size: 1,
                 send_fanout: 1,


### PR DESCRIPTION
Changes:
- added optional `--target-tps` (tx/sec)
- when unset, the max‑TPS path is unchanged
- when set, batch generation is paced to smooth traffic
- added a simple worker heuristic for rate‑limited mode
- updated tests and CLI parsing coverage

Validation:
- `cargo +nightly-2025-12-05 fmt --all`
- `cargo +nightly-2025-12-05 sort --workspace`
- `cargo +nightly-2025-12-05 check --locked --workspace --all-targets`
- `cargo +nightly-2025-12-05 clippy --workspace --all-targets -- --deny=warnings --deny=clippy::default_trait_access --deny=clippy::arithmetic_side_effects --deny=clippy::manual_let_else --deny=clippy::uninlined-format-args --deny=clippy::used_underscore_binding`

Part of #17 