### PR TITLE
Allow multiple tpu-client-next instances

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9915,6 +9915,7 @@ dependencies = [
  "solana-keypair",
  "solana-measure",
  "solana-message 4.0.0",
+ "solana-metrics",
  "solana-native-token",
  "solana-net-utils",
  "solana-pubkey 4.1.0",

--- a/transaction-bench/Cargo.toml
+++ b/transaction-bench/Cargo.toml
@@ -33,6 +33,7 @@ solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-measure = { workspace = true }
+solana-metrics = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-quic-definitions = { workspace = true }

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -99,8 +99,14 @@ pub enum Command {
 #[clap(rename_all = "kebab-case")]
 pub struct ExecutionParams {
     // Cannot use value_parser to read keypair file because Keypair is not Clone.
-    #[clap(long, help = "validator identity for staked connection.")]
-    pub staked_identity_file: Option<PathBuf>,
+    #[clap(
+        long = "staked-identity-file",
+        help = "Validator identity keypair file for staked connection. Spawns one \
+                tpu-client-next instance per occurrence. Repeat the same file to get multiple \
+                connections under one identity, or use different files for distinct stake \
+                allocations. Without this flag a single unstaked instance is used."
+    )]
+    pub staked_identity_files: Vec<PathBuf>,
 
     /// Address to bind on, default will listen on all available interfaces, 0 that
     /// OS will choose the port.
@@ -148,14 +154,6 @@ pub struct ExecutionParams {
     #[clap(long, help = "Sets compute-unit-price for transactions.")]
     pub compute_unit_price: Option<u64>,
 
-    #[clap(
-        long,
-        default_value_t = 1,
-        help = "Number of tpu-client-next instances to spawn. Each instance opens its own \
-                connection(s) to leader nodes, enabling multiple concurrent connections to the \
-                same peer. Generated transactions are distributed evenly across instances."
-    )]
-    pub num_tpu_clients: usize,
 
     #[clap(subcommand)]
     pub leader_tracker: LeaderTracker,
@@ -307,7 +305,7 @@ mod tests {
                 "127.0.0.1:8009",
             ],
             ExecutionParams {
-                staked_identity_file: Some(PathBuf::from(&keypair_file_name)),
+                staked_identity_files: vec![PathBuf::from(&keypair_file_name)],
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
                 duration: Some(Duration::from_secs(120)),
                 target_tps: None,
@@ -318,7 +316,6 @@ mod tests {
                 workers_pull_size: 8,
                 send_fanout: 2,
                 compute_unit_price: Some(1000),
-                num_tpu_clients: 1,
             },
         )
     }

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -148,6 +148,15 @@ pub struct ExecutionParams {
     #[clap(long, help = "Sets compute-unit-price for transactions.")]
     pub compute_unit_price: Option<u64>,
 
+    #[clap(
+        long,
+        default_value_t = 1,
+        help = "Number of tpu-client-next instances to spawn. Each instance opens its own \
+                connection(s) to leader nodes, enabling multiple concurrent connections to the \
+                same peer. Generated transactions are distributed evenly across instances."
+    )]
+    pub num_tpu_clients: usize,
+
     #[clap(subcommand)]
     pub leader_tracker: LeaderTracker,
 }
@@ -309,6 +318,7 @@ mod tests {
                 workers_pull_size: 8,
                 send_fanout: 2,
                 compute_unit_price: Some(1000),
+                num_tpu_clients: 1,
             },
         )
     }

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -34,7 +34,7 @@ pub enum TransactionGeneratorError {
 pub struct TransactionGenerator {
     accounts: AccountsFile,
     blockhash_receiver: watch::Receiver<Hash>,
-    transactions_sender: Sender<TransactionBatch>,
+    transactions_senders: Vec<Sender<TransactionBatch>>,
     transaction_params: TransactionParams,
     send_batch_size: usize,
     run_duration: Option<Duration>,
@@ -46,7 +46,7 @@ impl TransactionGenerator {
     pub fn new(
         accounts: AccountsFile,
         blockhash_receiver: watch::Receiver<Hash>,
-        transactions_sender: Sender<TransactionBatch>,
+        transactions_senders: Vec<Sender<TransactionBatch>>,
         transaction_params: TransactionParams,
         send_batch_size: usize,
         duration: Option<Duration>,
@@ -56,7 +56,7 @@ impl TransactionGenerator {
         Self {
             accounts,
             blockhash_receiver,
-            transactions_sender,
+            transactions_senders,
             transaction_params,
             send_batch_size,
             run_duration: duration,
@@ -103,6 +103,8 @@ impl TransactionGenerator {
             return Err(TransactionGeneratorError::GenerateTxBatchFailure);
         }
 
+        let num_senders = self.transactions_senders.len();
+        let mut sender_index: usize = 0;
         let start = Instant::now();
         let mut next_batch_at = self.target_tps.map(|_| start);
         loop {
@@ -116,7 +118,7 @@ impl TransactionGenerator {
                 break;
             }
 
-            if self.transactions_sender.is_closed() {
+            if self.transactions_senders.iter().all(|s| s.is_closed()) {
                 return Err(TransactionGeneratorError::ReceiverDropped);
             }
             let blockhash = *self.blockhash_receiver.borrow();
@@ -128,7 +130,8 @@ impl TransactionGenerator {
                 let send_batch_size = self.send_batch_size;
                 let transaction_params = self.transaction_params.clone();
                 let payers = payers.clone();
-                let transactions_sender = self.transactions_sender.clone();
+                let transactions_sender = self.transactions_senders[sender_index].clone();
+                sender_index = (sender_index + 1) % num_senders;
                 let transaction_type = TransactionType::Transfer;
 
                 match transaction_type {

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -6,8 +6,8 @@ use {
         generator::TransactionGenerator,
     },
     log::*,
-    solana_metrics::datapoint_info,
     solana_keypair::Keypair,
+    solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
     solana_quic_definitions::{
         QUIC_MAX_STAKED_CONCURRENT_STREAMS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
@@ -175,7 +175,7 @@ pub async fn run_client(
     accounts: AccountsFile,
     transaction_params: TransactionParams,
     ExecutionParams {
-        staked_identity_files,
+        staked_identity_file,
         bind,
         duration,
         target_tps,
@@ -184,21 +184,23 @@ pub async fn run_client(
         send_fanout,
         //TODO(klykov): pass to tx generator
         compute_unit_price: _,
+        num_tpu_clients,
         leader_tracker,
     }: ExecutionParams,
 ) -> Result<(), BenchClientError> {
-    let validator_identities: Vec<Keypair> = staked_identity_files
-        .into_iter()
-        .map(|path| {
-            Keypair::read_from_file(&path).map_err(|_err| BenchClientError::KeypairReadFailure)
-        })
-        .collect::<Result<_, _>>()?;
-    let num_tpu_clients = validator_identities.len().max(1);
+    let validator_identity = if let Some(staked_identity_file) = staked_identity_file {
+        Some(
+            Keypair::read_from_file(staked_identity_file)
+                .map_err(|_err| BenchClientError::KeypairReadFailure)?,
+        )
+    } else {
+        None
+    };
 
     // Set up size of the txs batch to put into the queue to be equal to the num_streams_per_connection
     let num_streams_per_connection = compute_num_streams(
         &rpc_client,
-        validator_identities.first().map(|keypair| keypair.pubkey()),
+        validator_identity.as_ref().map(|keypair| keypair.pubkey()),
     )
     .await
     .unwrap_or(DEFAULT_NUM_STREAMS_PER_CONNECTION);
@@ -300,7 +302,7 @@ pub async fn run_client(
     let mut scheduler_handles: Vec<JoinHandle<Result<(), BenchClientError>>> =
         Vec::with_capacity(num_tpu_clients);
     let mut all_stats: Vec<Arc<SendTransactionStats>> = Vec::with_capacity(num_tpu_clients);
-    for (i, transaction_receiver) in transaction_receivers.into_iter().enumerate() {
+    for transaction_receiver in transaction_receivers {
         let leader_updater = create_leader_updater(
             rpc_client.clone(),
             leader_tracker.clone(),
@@ -310,8 +312,8 @@ pub async fn run_client(
         )
         .await?;
 
-        let stake_identity = validator_identities
-            .get(i)
+        let stake_identity = validator_identity
+            .as_ref()
             .map(|ident| StakeIdentity::new(ident));
         let scheduler_config = ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Address(bind),
@@ -337,14 +339,13 @@ pub async fn run_client(
         );
         all_stats.push(scheduler.get_stats());
 
-        let scheduler_handle: JoinHandle<Result<(), BenchClientError>> =
-            tokio::spawn(async move {
-                let broadcaster = Box::new(BackpressuredBroadcaster {});
-                scheduler
-                    .run_with_broadcaster(scheduler_config, broadcaster)
-                    .await?;
-                Ok(())
-            });
+        let scheduler_handle: JoinHandle<Result<(), BenchClientError>> = tokio::spawn(async move {
+            let broadcaster = Box::new(BackpressuredBroadcaster {});
+            scheduler
+                .run_with_broadcaster(scheduler_config, broadcaster)
+                .await?;
+            Ok(())
+        });
         scheduler_handles.push(scheduler_handle);
     }
 

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -6,6 +6,7 @@ use {
         generator::TransactionGenerator,
     },
     log::*,
+    solana_metrics::datapoint_info,
     solana_keypair::Keypair,
     solana_pubkey::Pubkey,
     solana_quic_definitions::{
@@ -16,7 +17,7 @@ use {
     solana_signer::{EncodableKey, Signer},
     solana_streamer::nonblocking::quic::ConnectionPeerType,
     solana_tpu_client_next::{
-        ConnectionWorkersScheduler,
+        ConnectionWorkersScheduler, SendTransactionStats,
         connection_workers_scheduler::{
             BindTarget, ConnectionWorkersSchedulerConfig, Fanout, StakeIdentity,
         },
@@ -121,6 +122,53 @@ where
     }
 }
 
+/// Periodically reads and resets stats from all scheduler instances, sums them,
+/// and reports the aggregate to InfluxDB under a single metric name.
+#[allow(clippy::arithmetic_side_effects)]
+async fn report_aggregated_stats(
+    all_stats: Vec<Arc<SendTransactionStats>>,
+    reporting_interval: Duration,
+    cancel: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(reporting_interval);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                let (mut connect_error, mut connection_error, mut successfully_sent,
+                     mut congestion_events, mut write_error) = (0i64, 0i64, 0i64, 0i64, 0i64);
+                for stats in &all_stats {
+                    let view = stats.read_and_reset();
+                    connect_error += (view.connect_error_cids_exhausted
+                        + view.connect_error_other
+                        + view.connect_error_invalid_remote_address) as i64;
+                    connection_error += (view.connection_error_reset
+                        + view.connection_error_cids_exhausted
+                        + view.connection_error_timed_out
+                        + view.connection_error_application_closed
+                        + view.connection_error_transport_error
+                        + view.connection_error_version_mismatch
+                        + view.connection_error_locally_closed) as i64;
+                    successfully_sent += view.successfully_sent as i64;
+                    congestion_events += view.transport_congestion_events as i64;
+                    write_error += (view.write_error_stopped
+                        + view.write_error_closed_stream
+                        + view.write_error_connection_lost
+                        + view.write_error_zero_rtt_rejected) as i64;
+                }
+                datapoint_info!(
+                    "transaction-bench-network",
+                    ("connect_error", connect_error, i64),
+                    ("connection_error", connection_error, i64),
+                    ("successfully_sent", successfully_sent, i64),
+                    ("congestion_events", congestion_events, i64),
+                    ("write_error", write_error, i64),
+                );
+            }
+            _ = cancel.cancelled() => break,
+        }
+    }
+}
+
 pub async fn run_client(
     rpc_client: Arc<RpcClient>,
     websocket_url: String,
@@ -136,6 +184,7 @@ pub async fn run_client(
         send_fanout,
         //TODO(klykov): pass to tx generator
         compute_unit_price: _,
+        num_tpu_clients,
         leader_tracker,
     }: ExecutionParams,
 ) -> Result<(), BenchClientError> {
@@ -217,13 +266,19 @@ pub async fn run_client(
 
     let blockhash_task_handle = tokio::spawn(async move { blockhash_updater.run().await });
 
-    // Use bounded to avoid producing too many batches of transactions.
-    let (transaction_sender, transaction_receiver) = mpsc::channel(GENERATOR_CHANNEL_SIZE);
+    // Create N channels, one per tpu-client-next instance.
+    let mut transaction_senders = Vec::with_capacity(num_tpu_clients);
+    let mut transaction_receivers = Vec::with_capacity(num_tpu_clients);
+    for _ in 0..num_tpu_clients {
+        let (sender, receiver) = mpsc::channel(GENERATOR_CHANNEL_SIZE);
+        transaction_senders.push(sender);
+        transaction_receivers.push(receiver);
+    }
 
     let transaction_generator = TransactionGenerator::new(
         accounts,
         blockhash_receiver,
-        transaction_sender,
+        transaction_senders,
         transaction_params,
         send_batch_size,
         duration,
@@ -239,19 +294,31 @@ pub async fn run_client(
         refresh_nodes_info_every: Duration::from_secs(30),
         max_consecutive_failures: 5,
     };
-    let leader_updater = create_leader_updater(
-        rpc_client.clone(),
-        leader_tracker,
-        config,
-        websocket_url,
-        cancel.clone(),
-    )
-    .await?;
 
-    let scheduler_handle: JoinHandle<Result<(), BenchClientError>> = tokio::spawn(async move {
-        let config = ConnectionWorkersSchedulerConfig {
+    if num_tpu_clients > 1 {
+        info!("Spawning {num_tpu_clients} tpu-client-next instances.");
+    }
+
+    let mut scheduler_handles: Vec<JoinHandle<Result<(), BenchClientError>>> =
+        Vec::with_capacity(num_tpu_clients);
+    let mut all_stats: Vec<Arc<SendTransactionStats>> = Vec::with_capacity(num_tpu_clients);
+    for transaction_receiver in transaction_receivers {
+        let leader_updater = create_leader_updater(
+            rpc_client.clone(),
+            leader_tracker.clone(),
+            config.clone(),
+            websocket_url.clone(),
+            cancel.clone(),
+        )
+        .await?;
+
+        let stake_identity =
+            validator_identity
+                .as_ref()
+                .map(|ident| StakeIdentity::new(ident));
+        let scheduler_config = ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Address(bind),
-            stake_identity: validator_identity.map(|ident| StakeIdentity::new(&ident)),
+            stake_identity,
             num_connections: num_max_open_connections,
             worker_channel_size: WORKER_CHANNEL_SIZE,
             max_reconnect_attempts: MAX_RECONNECT_ATTEMPTS,
@@ -264,27 +331,39 @@ pub async fn run_client(
         };
 
         let (_, update_identity_receiver) = watch::channel(None);
+        let cancel_clone = cancel.clone();
         let scheduler = ConnectionWorkersScheduler::new(
             leader_updater,
             transaction_receiver,
             update_identity_receiver,
-            cancel.clone(),
+            cancel_clone,
         );
-        // leaking handle to this task, as it will run until the cancel signal is received
-        tokio::spawn(scheduler.get_stats().report_to_influxdb(
-            "transaction-bench-network",
-            METRICS_REPORTING_INTERVAL,
-            cancel,
-        ));
+        all_stats.push(scheduler.get_stats());
 
-        let broadcaster = Box::new(BackpressuredBroadcaster {});
-        scheduler.run_with_broadcaster(config, broadcaster).await?;
-        Ok(())
-    });
+        let scheduler_handle: JoinHandle<Result<(), BenchClientError>> =
+            tokio::spawn(async move {
+                let broadcaster = Box::new(BackpressuredBroadcaster {});
+                scheduler
+                    .run_with_broadcaster(scheduler_config, broadcaster)
+                    .await?;
+                Ok(())
+            });
+        scheduler_handles.push(scheduler_handle);
+    }
+
+    // Single metrics reporter aggregating stats across all tpu-client-next instances.
+    tokio::spawn(report_aggregated_stats(
+        all_stats,
+        METRICS_REPORTING_INTERVAL,
+        cancel,
+    ));
 
     join_service(transaction_generator_task_handle, "TransactionGenerator").await?;
     join_service(blockhash_task_handle, "BlockhashUpdater").await?;
-    join_service(scheduler_handle, "Scheduler").await?;
+    for (i, handle) in scheduler_handles.into_iter().enumerate() {
+        let name = format!("Scheduler-{i}");
+        join_service(handle, &name).await?;
+    }
     Ok(())
 }
 

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -175,7 +175,7 @@ pub async fn run_client(
     accounts: AccountsFile,
     transaction_params: TransactionParams,
     ExecutionParams {
-        staked_identity_file,
+        staked_identity_files,
         bind,
         duration,
         target_tps,
@@ -184,23 +184,21 @@ pub async fn run_client(
         send_fanout,
         //TODO(klykov): pass to tx generator
         compute_unit_price: _,
-        num_tpu_clients,
         leader_tracker,
     }: ExecutionParams,
 ) -> Result<(), BenchClientError> {
-    let validator_identity = if let Some(staked_identity_file) = staked_identity_file {
-        Some(
-            Keypair::read_from_file(staked_identity_file)
-                .map_err(|_err| BenchClientError::KeypairReadFailure)?,
-        )
-    } else {
-        None
-    };
+    let validator_identities: Vec<Keypair> = staked_identity_files
+        .into_iter()
+        .map(|path| {
+            Keypair::read_from_file(&path).map_err(|_err| BenchClientError::KeypairReadFailure)
+        })
+        .collect::<Result<_, _>>()?;
+    let num_tpu_clients = validator_identities.len().max(1);
 
     // Set up size of the txs batch to put into the queue to be equal to the num_streams_per_connection
     let num_streams_per_connection = compute_num_streams(
         &rpc_client,
-        validator_identity.as_ref().map(|keypair| keypair.pubkey()),
+        validator_identities.first().map(|keypair| keypair.pubkey()),
     )
     .await
     .unwrap_or(DEFAULT_NUM_STREAMS_PER_CONNECTION);
@@ -302,7 +300,7 @@ pub async fn run_client(
     let mut scheduler_handles: Vec<JoinHandle<Result<(), BenchClientError>>> =
         Vec::with_capacity(num_tpu_clients);
     let mut all_stats: Vec<Arc<SendTransactionStats>> = Vec::with_capacity(num_tpu_clients);
-    for transaction_receiver in transaction_receivers {
+    for (i, transaction_receiver) in transaction_receivers.into_iter().enumerate() {
         let leader_updater = create_leader_updater(
             rpc_client.clone(),
             leader_tracker.clone(),
@@ -312,10 +310,9 @@ pub async fn run_client(
         )
         .await?;
 
-        let stake_identity =
-            validator_identity
-                .as_ref()
-                .map(|ident| StakeIdentity::new(ident));
+        let stake_identity = validator_identities
+            .get(i)
+            .map(|ident| StakeIdentity::new(ident));
         let scheduler_config = ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Address(bind),
             stake_identity,

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -130,7 +130,7 @@ fn test_transactions_sending() {
                 },
             },
             ExecutionParams {
-                staked_identity_file: None,
+                staked_identity_files: vec![],
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
                 duration: Some(Duration::from_secs(5)),
                 target_tps: None,
@@ -138,7 +138,6 @@ fn test_transactions_sending() {
                 workers_pull_size: 1,
                 send_fanout: 1,
                 compute_unit_price: Some(100),
-                num_tpu_clients: 1,
                 leader_tracker: LeaderTracker::PinnedLeaderTracker { address: tpu_addr },
             },
         )

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -138,6 +138,7 @@ fn test_transactions_sending() {
                 workers_pull_size: 1,
                 send_fanout: 1,
                 compute_unit_price: Some(100),
+                num_tpu_clients: 1,
                 leader_tracker: LeaderTracker::PinnedLeaderTracker { address: tpu_addr },
             },
         )


### PR DESCRIPTION
This allows for more TPS when over long link to one leader.

This is better than multiple independent instances as TX flow will contain no duplicates (it is split between clients). Emulates e.g. a relayer sending from multiple locations.