### PR TITLE
add support of txv1

### DIFF
--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -154,7 +154,6 @@ pub struct ExecutionParams {
     #[clap(long, help = "Sets compute-unit-price for transactions.")]
     pub compute_unit_price: Option<u64>,
 
-
     #[clap(subcommand)]
     pub leader_tracker: LeaderTracker,
 }
@@ -167,6 +166,9 @@ pub struct TransactionParams {
 
     #[clap(flatten)]
     pub padding_params: InstructionPaddingParams,
+
+    #[clap(long, help = "Generate and send transfer transactions in V1 format.")]
+    pub use_txv1: bool,
     //TODO(klykov): memo
 }
 
@@ -198,7 +200,7 @@ pub struct InstructionPaddingConfig {
 
 // In case of plain transfer transaction, set loaded account data size to 30 KiB.
 // It is large enough yet smaller than 32 KiB page size, so it would cost 0 extra CU.
-const TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE: u32 = 30 * 1024;
+pub(crate) const TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE: u32 = 30 * 1024;
 // In case of padding program usage, we need to take into account program size too.
 const PADDING_PROGRAM_ACCOUNT_DATA_SIZE: u32 = 28 * 1024;
 
@@ -356,6 +358,7 @@ mod tests {
                         instruction_padding_data_size: None,
                         instruction_padding_program_id: None,
                     },
+                    use_txv1: false,
                 },
                 account_params,
                 execution_params,
@@ -409,6 +412,7 @@ mod tests {
                         instruction_padding_data_size: None,
                         instruction_padding_program_id: None,
                     },
+                    use_txv1: false,
                 },
                 execution_params,
             },
@@ -436,6 +440,7 @@ mod tests {
                 instruction_padding_data_size: Some(128),
                 instruction_padding_program_id: None,
             },
+            use_txv1: false,
         };
 
         let padding_config = params.instruction_padding_config().unwrap();
@@ -484,6 +489,35 @@ mod tests {
         assert_eq!(actual_account_params, account_params);
         assert_eq!(actual_execution_params, execution_params);
     }
+
+    #[test]
+    fn test_use_txv1_transaction_param() {
+        let keypair_file_name = "/home/testUser/masterKey.json";
+
+        let mut args = vec![
+            "test",
+            "-ul",
+            "--authority",
+            keypair_file_name,
+            "run",
+            "--use-txv1",
+        ];
+        let (account_args, _account_params) = get_common_account_params();
+        args.extend(account_args.iter());
+        let (exec_args, _execution_params) = get_common_execution_params(keypair_file_name);
+        args.extend(exec_args.iter());
+
+        let actual = ClientCliParameters::try_parse_from(args).unwrap();
+        let Command::Run {
+            transaction_params, ..
+        } = actual.command
+        else {
+            panic!("expected run command");
+        };
+
+        assert!(transaction_params.use_txv1);
+    }
+
     #[test]
     fn test_write_accounts_command() {
         let keypair_file_name = "/home/testUser/masterKey.json";

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -101,10 +101,10 @@ pub struct ExecutionParams {
     // Cannot use value_parser to read keypair file because Keypair is not Clone.
     #[clap(
         long = "staked-identity-file",
-        help = "Validator identity keypair file for staked connection. Spawns one \
-                tpu-client-next instance per occurrence. Repeat the same file to get multiple \
-                connections under one identity, or use different files for distinct stake \
-                allocations. Without this flag a single unstaked instance is used."
+        help = "Validator identity keypair file for staked connection. Spawns one tpu-client-next \
+                instance per occurrence. Repeat the same file to get multiple connections under \
+                one identity, or use different files for distinct stake allocations. Without this \
+                flag a single unstaked instance is used."
     )]
     pub staked_identity_files: Vec<PathBuf>,
 

--- a/transaction-bench/src/generator/simple_transfers_generator.rs
+++ b/transaction-bench/src/generator/simple_transfers_generator.rs
@@ -18,7 +18,9 @@ pub(crate) fn generate_transfer_transaction_batch(
     TransactionParams {
         simple_transfer_tx_params,
         padding_params,
+        use_txv1,
     }: TransactionParams,
+    compute_unit_price: Option<u64>,
     send_batch_size: usize,
 ) -> JoinHandle<Vec<Vec<u8>>> {
     spawn_blocking_transaction_batch_generation("generate transfer transaction batch", move || {
@@ -26,6 +28,7 @@ pub(crate) fn generate_transfer_transaction_batch(
         let instruction_padding_config = TransactionParams {
             simple_transfer_tx_params: simple_transfer_tx_params.clone(),
             padding_params: padding_params.clone(),
+            use_txv1,
         }
         .instruction_padding_config();
 
@@ -57,6 +60,8 @@ pub(crate) fn generate_transfer_transaction_batch(
                 num_send_instructions_per_tx,
                 transfer_tx_cu_budget,
                 instruction_padding_config.as_ref(),
+                compute_unit_price,
+                use_txv1,
             );
             txs.push(tx);
             instructions.clear();

--- a/transaction-bench/src/generator/transaction_builder.rs
+++ b/transaction-bench/src/generator/transaction_builder.rs
@@ -43,6 +43,7 @@ pub(crate) fn create_serialized_signed_transaction(
     wincode::serialize(&tx).expect("serialize VersionedTransaction in send_batch")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub(crate) fn create_serialized_transfers<'a, S, R, L>(
     accounts_from: &mut S,
     accounts_to: &mut R,

--- a/transaction-bench/src/generator/transaction_builder.rs
+++ b/transaction-bench/src/generator/transaction_builder.rs
@@ -1,9 +1,14 @@
 use {
-    crate::cli::InstructionPaddingConfig,
+    crate::cli::{InstructionPaddingConfig, TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE},
     solana_compute_budget_interface::ComputeBudgetInstruction,
     solana_hash::Hash,
     solana_instruction::Instruction,
     solana_keypair::Keypair,
+    solana_message::{
+        VersionedMessage,
+        v1::{Message as V1Message, TransactionConfig},
+    },
+    solana_pubkey::Pubkey,
     solana_signer::Signer,
     solana_system_interface::instruction as system_instruction,
     solana_transaction::{Transaction, versioned::VersionedTransaction},
@@ -48,26 +53,14 @@ pub(crate) fn create_serialized_transfers<'a, S, R, L>(
     num_send_instructions_per_tx: usize,
     transaction_cu_budget: u32,
     instruction_padding_config: Option<&InstructionPaddingConfig>,
+    compute_unit_price: Option<u64>,
+    use_txv1: bool,
 ) -> Vec<u8>
 where
     S: Iterator<Item = &'a Keypair>,
     R: Iterator<Item = &'a Keypair>,
     L: Iterator<Item = &'a u64>,
 {
-    if let Some(padding_config) = instruction_padding_config {
-        instructions.insert(
-            0,
-            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
-                padding_config.loaded_accounts_data_size_limit,
-            ),
-        );
-    }
-
-    instructions.insert(
-        0,
-        ComputeBudgetInstruction::set_compute_unit_limit(transaction_cu_budget),
-    );
-
     // First account-from is also the transaction fee payer
     let tx_payer_kp = accounts_from.next().unwrap();
     let tx_payer = &tx_payer_kp.pubkey();
@@ -98,11 +91,107 @@ where
         ));
     }
 
-    let tx: VersionedTransaction =
-        Transaction::new_signed_with_payer(instructions, Some(tx_payer), signers, recent_blockhash)
-            .into();
+    let tx = create_transfer_transaction(
+        tx_payer,
+        instructions,
+        signers,
+        recent_blockhash,
+        transaction_cu_budget,
+        instruction_padding_config,
+        compute_unit_price,
+        use_txv1,
+    );
 
     wincode::serialize(&tx).expect("serialize VersionedTransaction in send_batch")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn create_transfer_transaction(
+    tx_payer: &Pubkey,
+    instructions: &mut Vec<Instruction>,
+    signers: &[&Keypair],
+    recent_blockhash: Hash,
+    transaction_cu_budget: u32,
+    instruction_padding_config: Option<&InstructionPaddingConfig>,
+    compute_unit_price: Option<u64>,
+    use_txv1: bool,
+) -> VersionedTransaction {
+    if use_txv1 {
+        create_v1_transfer_transaction(
+            tx_payer,
+            instructions,
+            signers,
+            recent_blockhash,
+            transaction_cu_budget,
+            instruction_padding_config,
+            compute_unit_price,
+        )
+    } else {
+        create_legacy_transfer_transaction(
+            tx_payer,
+            instructions,
+            signers,
+            recent_blockhash,
+            transaction_cu_budget,
+            instruction_padding_config,
+            compute_unit_price,
+        )
+    }
+}
+
+fn create_legacy_transfer_transaction(
+    tx_payer: &Pubkey,
+    instructions: &mut Vec<Instruction>,
+    signers: &[&Keypair],
+    recent_blockhash: Hash,
+    transaction_cu_budget: u32,
+    instruction_padding_config: Option<&InstructionPaddingConfig>,
+    compute_unit_price: Option<u64>,
+) -> VersionedTransaction {
+    let mut compute_budget_instructions = vec![ComputeBudgetInstruction::set_compute_unit_limit(
+        transaction_cu_budget,
+    )];
+    if let Some(compute_unit_price) = compute_unit_price {
+        compute_budget_instructions.push(ComputeBudgetInstruction::set_compute_unit_price(
+            compute_unit_price,
+        ));
+    }
+    if let Some(padding_config) = instruction_padding_config {
+        compute_budget_instructions.push(
+            ComputeBudgetInstruction::set_loaded_accounts_data_size_limit(
+                padding_config.loaded_accounts_data_size_limit,
+            ),
+        );
+    }
+    instructions.splice(0..0, compute_budget_instructions);
+
+    Transaction::new_signed_with_payer(instructions, Some(tx_payer), signers, recent_blockhash)
+        .into()
+}
+
+fn create_v1_transfer_transaction(
+    tx_payer: &Pubkey,
+    instructions: &[Instruction],
+    signers: &[&Keypair],
+    recent_blockhash: Hash,
+    transaction_cu_budget: u32,
+    instruction_padding_config: Option<&InstructionPaddingConfig>,
+    compute_unit_price: Option<u64>,
+) -> VersionedTransaction {
+    let loaded_accounts_data_size_limit = instruction_padding_config
+        .map(|padding_config| padding_config.loaded_accounts_data_size_limit)
+        .unwrap_or(TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE);
+    let mut config = TransactionConfig::empty()
+        .with_compute_unit_limit(transaction_cu_budget)
+        .with_loaded_accounts_data_size_limit(loaded_accounts_data_size_limit);
+    if let Some(compute_unit_price) = compute_unit_price {
+        config = config.with_priority_fee(compute_unit_price);
+    }
+
+    let message =
+        V1Message::try_compile_with_config(tx_payer, instructions, recent_blockhash, config)
+            .unwrap();
+    VersionedTransaction::try_new(VersionedMessage::V1(message), signers).unwrap()
 }
 
 fn maybe_wrap_instruction(
@@ -123,7 +212,7 @@ fn maybe_wrap_instruction(
 
 #[cfg(test)]
 mod tests {
-    use {super::*, solana_pubkey::Pubkey};
+    use {super::*, solana_message::VersionedMessage, solana_pubkey::Pubkey};
 
     #[test]
     fn test_maybe_wrap_instruction_keeps_transfer_when_disabled() {
@@ -152,5 +241,67 @@ mod tests {
 
         assert_eq!(instruction.program_id, padding_program_id);
         assert!(!instruction.data.is_empty());
+    }
+
+    #[test]
+    fn test_create_serialized_transfers_uses_legacy_by_default() {
+        let tx = create_test_transfer(None, false);
+
+        assert!(matches!(&tx.message, VersionedMessage::Legacy(_)));
+        assert_eq!(tx.message.instructions().len(), 2);
+    }
+
+    #[test]
+    fn test_create_serialized_transfers_adds_legacy_compute_unit_price() {
+        let tx = create_test_transfer(Some(1), false);
+
+        assert!(matches!(&tx.message, VersionedMessage::Legacy(_)));
+        assert_eq!(tx.message.instructions().len(), 3);
+    }
+
+    #[test]
+    fn test_create_serialized_transfers_uses_v1_when_enabled() {
+        let tx = create_test_transfer(Some(1), true);
+        let VersionedMessage::V1(message) = tx.message else {
+            panic!("expected v1 message");
+        };
+
+        assert_eq!(message.config.compute_unit_limit, Some(600));
+        assert_eq!(message.config.priority_fee, Some(1));
+        assert_eq!(
+            message.config.loaded_accounts_data_size_limit,
+            Some(TRANSFER_TRANSACTION_LOADED_ACCOUNTS_DATA_SIZE)
+        );
+        assert_eq!(message.instructions.len(), 1);
+    }
+
+    fn create_test_transfer(
+        compute_unit_price: Option<u64>,
+        use_txv1: bool,
+    ) -> VersionedTransaction {
+        let sender = Keypair::new();
+        let receiver = Keypair::new();
+        let lamports = [1];
+        let mut accounts_from = [&sender].into_iter();
+        let mut accounts_to = [&receiver].into_iter();
+        let mut lamports = lamports.iter();
+        let mut instructions = Vec::new();
+        let mut signers = Vec::new();
+
+        let wire_transaction = create_serialized_transfers(
+            &mut accounts_from,
+            &mut accounts_to,
+            &mut lamports,
+            Hash::new_unique(),
+            &mut instructions,
+            &mut signers,
+            1,
+            600,
+            None,
+            compute_unit_price,
+            use_txv1,
+        );
+
+        wincode::deserialize(&wire_transaction).unwrap()
     }
 }

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -78,24 +78,13 @@ impl TransactionGenerator {
         //TODO(klykov): extract to function
         // Validate inputs that couldn't be done in CLI due to interdependency between two CLI args.
         // Ensure CU budget is sufficient for multi-instruction transfer transactions.
-        let &SimpleTransferTxParams {
-            num_send_instructions_per_tx,
-            transfer_tx_cu_budget,
-            ..
-        } = &self.transaction_params.simple_transfer_tx_params;
-
-        let per_instruction_cu_cost = if self
+        let transfer_tx_cu_budget = self
             .transaction_params
-            .padding_params
-            .instruction_padding_data_size
-            .is_some()
-        {
-            PADDED_TRANSFER_INSTRUCTION_CU_COST
-        } else {
-            SIMPLE_TRANSFER_INSTRUCTION_CU_COST
-        };
-        let transfer_tx_min_cu_budget = COMPUTE_BUDGET_INSTRUCTION_CU_COST
-            + per_instruction_cu_cost * num_send_instructions_per_tx as u32;
+            .simple_transfer_tx_params
+            .transfer_tx_cu_budget;
+
+        let transfer_tx_min_cu_budget =
+            compute_transfer_tx_min_cu_budget(&self.transaction_params, self.compute_unit_price);
 
         if transfer_tx_cu_budget < transfer_tx_min_cu_budget {
             error!(
@@ -189,6 +178,38 @@ impl TransactionGenerator {
     }
 }
 
+#[allow(clippy::arithmetic_side_effects)]
+fn compute_transfer_tx_min_cu_budget(
+    transaction_params: &TransactionParams,
+    compute_unit_price: Option<u64>,
+) -> u32 {
+    let &SimpleTransferTxParams {
+        num_send_instructions_per_tx,
+        ..
+    } = &transaction_params.simple_transfer_tx_params;
+
+    let use_instruction_padding = transaction_params
+        .padding_params
+        .instruction_padding_data_size
+        .is_some();
+    let per_instruction_cu_cost = if use_instruction_padding {
+        PADDED_TRANSFER_INSTRUCTION_CU_COST
+    } else {
+        SIMPLE_TRANSFER_INSTRUCTION_CU_COST
+    };
+
+    // Legacy transfer transactions include explicit compute-budget instructions.
+    // V1 transfer transactions encode these settings in Message config.
+    let compute_budget_instructions_count = if transaction_params.use_txv1 {
+        0
+    } else {
+        1 + u32::from(compute_unit_price.is_some()) + u32::from(use_instruction_padding)
+    };
+
+    compute_budget_instructions_count * COMPUTE_BUDGET_INSTRUCTION_CU_COST
+        + per_instruction_cu_cost * num_send_instructions_per_tx as u32
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) enum TransactionType {
     Transfer,
@@ -221,7 +242,12 @@ fn compute_batch_interval(send_batch_size: usize, target_tps: NonZeroU64) -> Dur
 
 #[cfg(test)]
 mod tests {
-    use {super::compute_batch_interval, std::num::NonZeroU64, tokio::time::Duration};
+    use {
+        super::{compute_batch_interval, compute_transfer_tx_min_cu_budget},
+        crate::cli::{InstructionPaddingParams, SimpleTransferTxParams, TransactionParams},
+        std::num::NonZeroU64,
+        tokio::time::Duration,
+    };
 
     #[test]
     fn test_compute_batch_interval() {
@@ -233,5 +259,56 @@ mod tests {
             compute_batch_interval(1, NonZeroU64::new(1).unwrap()),
             Duration::from_secs(1)
         );
+    }
+
+    #[test]
+    fn test_transfer_tx_min_cu_budget_legacy_without_optional_compute_budget_instructions() {
+        let transaction_params = make_transaction_params(2, None, false);
+
+        let actual = compute_transfer_tx_min_cu_budget(&transaction_params, None);
+
+        // 1 compute-budget instruction + 2 simple transfer instructions.
+        assert_eq!(actual, 150 + 2 * 150);
+    }
+
+    #[test]
+    fn test_transfer_tx_min_cu_budget_legacy_with_price_and_padding() {
+        let transaction_params = make_transaction_params(2, Some(32), false);
+
+        let actual = compute_transfer_tx_min_cu_budget(&transaction_params, Some(1_000));
+
+        // 3 compute-budget instructions (limit + price + loaded-account-size) + 2 padded transfers.
+        assert_eq!(actual, 3 * 150 + 2 * 3_000);
+    }
+
+    #[test]
+    fn test_transfer_tx_min_cu_budget_v1_with_price_and_padding() {
+        let transaction_params = make_transaction_params(2, Some(32), true);
+
+        let actual = compute_transfer_tx_min_cu_budget(&transaction_params, Some(1_000));
+
+        // V1 configuration does not insert compute-budget instructions into the message.
+        assert_eq!(actual, 2 * 3_000);
+    }
+
+    fn make_transaction_params(
+        num_send_instructions_per_tx: usize,
+        instruction_padding_data_size: Option<u32>,
+        use_txv1: bool,
+    ) -> TransactionParams {
+        TransactionParams {
+            simple_transfer_tx_params: SimpleTransferTxParams {
+                lamports_to_transfer: 513,
+                transfer_tx_cu_budget: 600,
+                num_send_instructions_per_tx,
+                tx_batch_size: None,
+                num_conflict_groups: None,
+            },
+            padding_params: InstructionPaddingParams {
+                instruction_padding_data_size,
+                instruction_padding_program_id: None,
+            },
+            use_txv1,
+        }
     }
 }

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -36,6 +36,7 @@ pub struct TransactionGenerator {
     blockhash_receiver: watch::Receiver<Hash>,
     transactions_senders: Vec<Sender<TransactionBatch>>,
     transaction_params: TransactionParams,
+    compute_unit_price: Option<u64>,
     send_batch_size: usize,
     run_duration: Option<Duration>,
     target_tps: Option<NonZeroU64>,
@@ -48,6 +49,7 @@ impl TransactionGenerator {
         blockhash_receiver: watch::Receiver<Hash>,
         transactions_senders: Vec<Sender<TransactionBatch>>,
         transaction_params: TransactionParams,
+        compute_unit_price: Option<u64>,
         send_batch_size: usize,
         duration: Option<Duration>,
         target_tps: Option<NonZeroU64>,
@@ -58,6 +60,7 @@ impl TransactionGenerator {
             blockhash_receiver,
             transactions_senders,
             transaction_params,
+            compute_unit_price,
             send_batch_size,
             run_duration: duration,
             target_tps,
@@ -129,6 +132,7 @@ impl TransactionGenerator {
                 }
                 let send_batch_size = self.send_batch_size;
                 let transaction_params = self.transaction_params.clone();
+                let compute_unit_price = self.compute_unit_price;
                 let payers = payers.clone();
                 let transactions_sender = self.transactions_senders[sender_index].clone();
                 sender_index = (sender_index + 1) % num_senders;
@@ -148,6 +152,7 @@ impl TransactionGenerator {
                                 index_payer,
                                 blockhash,
                                 transaction_params,
+                                compute_unit_price,
                                 send_batch_size,
                             )
                             .await

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -182,8 +182,7 @@ pub async fn run_client(
         num_max_open_connections,
         workers_pull_size,
         send_fanout,
-        //TODO(klykov): pass to tx generator
-        compute_unit_price: _,
+        compute_unit_price,
         leader_tracker,
     }: ExecutionParams,
 ) -> Result<(), BenchClientError> {
@@ -278,6 +277,7 @@ pub async fn run_client(
         blockhash_receiver,
         transaction_senders,
         transaction_params,
+        compute_unit_price,
         send_batch_size,
         duration,
         target_tps,

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -310,9 +310,7 @@ pub async fn run_client(
         )
         .await?;
 
-        let stake_identity = validator_identities
-            .get(i)
-            .map(|ident| StakeIdentity::new(ident));
+        let stake_identity = validator_identities.get(i).map(StakeIdentity::new);
         let scheduler_config = ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Address(bind),
             stake_identity,

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -127,6 +127,7 @@ fn test_transactions_sending() {
                     instruction_padding_data_size: None,
                     instruction_padding_program_id: None,
                 },
+                use_txv1: false,
             },
             ExecutionParams {
                 staked_identity_files: vec![],
@@ -158,7 +159,7 @@ fn test_transactions_sending() {
                     let tx = encoded_tx.transaction.decode();
                     if let Some(tx) = tx
                         && is_transfer(&tx)
-                        && tx.message.instructions().len() == 2
+                        && tx.message.instructions().len() == 3
                     {
                         num_txs += 1;
                     }


### PR DESCRIPTION
To be able to send v1 format transactions in benching, changes:

- Added `--use-txv1` on TransactionParams
- Plumb `compute_unit_price` and `use_txv1` through the generator path.
- Split transfer construction:
      - legacy/v0 path still uses compute-budget instructions
      - v1 path builds VersionedMessage::V1 with TransactionConfig
- Wired `--compute-unit-price` into generated transfer txs, so legacy gets the compute-budget price instruction and v1 gets priority_fee.
- Added CLI and transaction-builder tests for legacy, legacy priority fee, and v1.