### PR TITLE
Move stats reporting from run_client for better testing

### DIFF
--- a/rate-latency-tool/src/main.rs
+++ b/rate-latency-tool/src/main.rs
@@ -10,12 +10,16 @@ use {
     },
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::{EncodableKey, Signer},
+    solana_tpu_client_next::SendTransactionStats,
     solana_tpu_tools_common::accounts_file::{
         create_ephemeral_accounts, create_file_persisted_accounts, read_accounts_file,
     },
-    std::sync::Arc,
+    std::{sync::Arc, time::Duration},
     tokio_util::sync::CancellationToken,
 };
+
+/// How often tpu-client-next reports network metrics.
+const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(1);
 
 fn main() {
     agave_logger::setup_with_default("solana=info");
@@ -66,15 +70,19 @@ async fn run(parameters: ClientCliParameters) -> Result<(), RateLatencyToolError
                 parameters.validate_accounts,
             )
             .await?;
-            run_client(
+            let stats = Arc::new(SendTransactionStats::default());
+            let metrics_task = spawn_metrics_reporter(stats.clone(), cancel.clone());
+            let result = run_client(
                 rpc_client,
                 websocket_url,
                 accounts,
                 execution_params,
                 analysis_params,
-                cancel,
+                stats,
+                cancel.clone(),
             )
-            .await?;
+            .await;
+            finish_client_run(result, cancel, metrics_task).await?;
         }
         Command::ReadAccountsRun {
             read_accounts,
@@ -82,15 +90,19 @@ async fn run(parameters: ClientCliParameters) -> Result<(), RateLatencyToolError
             analysis_params,
         } => {
             let accounts = read_accounts_file(read_accounts.accounts_file.clone());
-            run_client(
+            let stats = Arc::new(SendTransactionStats::default());
+            let metrics_task = spawn_metrics_reporter(stats.clone(), cancel.clone());
+            let result = run_client(
                 rpc_client,
                 websocket_url,
                 accounts,
                 execution_params,
                 analysis_params,
-                cancel,
+                stats,
+                cancel.clone(),
             )
-            .await?;
+            .await;
+            finish_client_run(result, cancel, metrics_task).await?;
         }
         Command::WriteAccounts(write_accounts) => {
             create_file_persisted_accounts(
@@ -106,4 +118,33 @@ async fn run(parameters: ClientCliParameters) -> Result<(), RateLatencyToolError
     }
 
     Ok(())
+}
+
+fn spawn_metrics_reporter(
+    stats: Arc<SendTransactionStats>,
+    cancel: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        stats
+            .report_to_influxdb(
+                "rate-latency-tool-network",
+                METRICS_REPORTING_INTERVAL,
+                cancel,
+            )
+            .await;
+    })
+}
+
+async fn finish_client_run(
+    result: Result<(), RateLatencyToolError>,
+    cancel: CancellationToken,
+    metrics_task: tokio::task::JoinHandle<()>,
+) -> Result<(), RateLatencyToolError> {
+    cancel.cancel();
+    if let Err(err) = metrics_task.await {
+        error!("Stats reporting task panicked: {err:?}");
+        result?;
+        return Err(RateLatencyToolError::UnexpectedError);
+    }
+    result
 }

--- a/rate-latency-tool/src/run_client.rs
+++ b/rate-latency-tool/src/run_client.rs
@@ -43,9 +43,6 @@ const CSV_RECORD_CHANNEL_SIZE: usize = 1024;
 /// in range 9000-20000.
 const MEMO_TX_CU: u32 = 20_000;
 
-/// How often tpu-client-next reports network metrics.
-const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(1);
-
 /// How long after stop sending transactions, we want to receive updates from
 /// yellowstone.
 const YELLOWSTONE_STREAM_SHUTDOWN_DELAY: Duration = Duration::from_secs(2);
@@ -71,6 +68,7 @@ pub async fn run_client(
         yellowstone_token,
         check_all_txs,
     }: TxAnalysisParams,
+    stats: Arc<SendTransactionStats>,
     cancel: CancellationToken,
 ) -> Result<(), RateLatencyToolError> {
     let validator_identity = if let Some(staked_identity_file) = staked_identity_file {
@@ -177,22 +175,6 @@ pub async fn run_client(
         cancel.clone(),
     )
     .await?;
-
-    let stats = Arc::new(SendTransactionStats::default());
-    tasks.spawn({
-        let stats = stats.clone();
-        let cancel = cancel_tx_sending.clone();
-        async move {
-            stats
-                .report_to_influxdb(
-                    "rate-latency-tool-network",
-                    METRICS_REPORTING_INTERVAL,
-                    cancel,
-                )
-                .await;
-            Ok(())
-        }
-    });
 
     tasks.spawn({
         let cancel = cancel_tx_sending.clone();

--- a/rate-latency-tool/tests/run_client.rs
+++ b/rate-latency-tool/tests/run_client.rs
@@ -16,10 +16,14 @@ use {
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::{
         config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter},
-        response::{RpcBlockUpdateError, transaction::versioned::VersionedTransaction},
+        response::{
+            Response, RpcBlockUpdate, RpcBlockUpdateError,
+            transaction::versioned::VersionedTransaction,
+        },
     },
     solana_signer::Signer,
     solana_test_validator::TestValidatorGenesis,
+    solana_tpu_client_next::SendTransactionStats,
     solana_tpu_tools_common::{
         accounts_file::create_ephemeral_accounts,
         cli::{AccountParams, LeaderTracker},
@@ -28,7 +32,7 @@ use {
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
         sync::Arc,
-        time::Duration,
+        time::{Duration, Instant},
     },
     tokio::runtime::Builder,
     tokio_util::sync::CancellationToken,
@@ -86,6 +90,8 @@ fn test_transactions_sending() {
     .unwrap();
 
     let cancel = CancellationToken::new();
+    let stats = Arc::new(SendTransactionStats::default());
+    let client_stats = stats.clone();
     let handle = rt.spawn(async {
         let funding_key = Keypair::new();
         let funding_pubkey = funding_key.pubkey();
@@ -116,10 +122,10 @@ fn test_transactions_sending() {
             ExecutionParams {
                 staked_identity_file: None,
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
-                duration: Some(Duration::from_secs(5)),
+                duration: Some(Duration::from_secs(2)),
                 num_max_open_connections: 1,
                 send_fanout: 1,
-                send_interval: Duration::from_millis(100),
+                send_interval: Duration::from_millis(50),
                 compute_unit_price: Some(100),
                 handshake_timeout: Duration::from_secs(2),
                 leader_tracker: LeaderTracker::WsLeaderTracker,
@@ -130,6 +136,7 @@ fn test_transactions_sending() {
                 yellowstone_token: None,
                 check_all_txs: false,
             },
+            client_stats,
             cancel,
         )
         .await
@@ -139,32 +146,25 @@ fn test_transactions_sending() {
         .expect("Should not fail joining client task.")
         .expect("Should not fail running client.");
 
-    let mut num_memo_tx = 0;
-    for _ in 0..10 {
-        receiver.try_iter().for_each(|response| {
-            if let Some(err) = response.value.err {
-                // sometimes block is not ready, see issues/33462
-                assert_eq!(err, RpcBlockUpdateError::BlockStoreError);
-            }
-            if let Some(block) = response.value.block
-                && let Some(encoded_transactions) = block.transactions
-            {
-                for encoded_tx in encoded_transactions {
-                    let tx = encoded_tx.transaction.decode();
-                    if let Some(tx) = tx
-                        && is_memo(tx)
-                    {
-                        num_memo_tx += 1;
-                    }
-                }
-            }
-        });
-        std::thread::sleep(Duration::from_secs(1));
+    let successfully_sent = stats.to_non_atomic().successfully_sent;
+    assert!(
+        successfully_sent > 0,
+        "Expected client to successfully send at least one memo tx"
+    );
+
+    let mut num_memo_tx = 0u64;
+    let before = Instant::now();
+    while num_memo_tx < successfully_sent && before.elapsed() < Duration::from_secs(10) {
+        num_memo_tx += count_memo_txs(receiver.try_iter());
+        if num_memo_tx < successfully_sent {
+            std::thread::sleep(Duration::from_millis(100));
+        }
     }
+    num_memo_tx += count_memo_txs(receiver.try_iter());
 
     assert_eq!(
-        num_memo_tx, 50,
-        "Expected to receive 50 memo txs but got {num_memo_tx}"
+        num_memo_tx, successfully_sent,
+        "Expected to receive {successfully_sent} memo txs but got {num_memo_tx}"
     );
     // If we don't drop the test_validator, the blocking web socket service
     // won't return, and the `block_subscribe_client` won't shut down
@@ -194,6 +194,29 @@ async fn wait_for_balance(client: &RpcClient, pubkey: &solana_pubkey::Pubkey, ta
         tokio::time::sleep(Duration::from_millis(200)).await;
     }
     panic!("Airdrop balance did not reach target {target} for {pubkey}");
+}
+
+fn count_memo_txs(responses: impl IntoIterator<Item = Response<RpcBlockUpdate>>) -> u64 {
+    let mut num_memo_tx = 0u64;
+    for response in responses {
+        if let Some(err) = response.value.err {
+            // sometimes block is not ready, see issues/33462
+            assert_eq!(err, RpcBlockUpdateError::BlockStoreError);
+        }
+        if let Some(block) = response.value.block
+            && let Some(encoded_transactions) = block.transactions
+        {
+            for encoded_tx in encoded_transactions {
+                let tx = encoded_tx.transaction.decode();
+                if let Some(tx) = tx
+                    && is_memo(tx)
+                {
+                    num_memo_tx = num_memo_tx.saturating_add(1);
+                }
+            }
+        }
+    }
+    num_memo_tx
 }
 
 fn is_memo(tx: VersionedTransaction) -> bool {

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -3,6 +3,7 @@ use {
     log::*,
     solana_cli_config::ConfigInput,
     solana_keypair::Keypair,
+    solana_metrics::datapoint_info,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::{EncodableKey, Signer},
     solana_tpu_tools_common::{
@@ -16,10 +17,15 @@ use {
         cli::{ClientCliParameters, Command, build_cli_parameters},
         error::BenchClientError,
         mock_rpc_client::new_mock_rpc_client,
-        run_client::run_client,
+        run_client::{RunClientStats, run_client},
     },
-    std::sync::Arc,
+    std::{sync::Arc, time::Duration},
+    tokio::{sync::oneshot, task::JoinHandle},
+    tokio_util::sync::CancellationToken,
 };
+
+/// How often tpu-client-next reports network metrics.
+const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(1);
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
 #[global_allocator]
@@ -87,14 +93,20 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
                 )
                 .await?
             };
-            run_client(
+            let cancel = CancellationToken::new();
+            let (stats_sender, stats_receiver) = oneshot::channel();
+            let metrics_task = spawn_metrics_reporter(stats_receiver, cancel.clone());
+            let result = run_client(
                 rpc_client,
                 websocket_url,
                 accounts,
                 transaction_params,
                 execution_params,
+                Some(stats_sender),
+                cancel.clone(),
             )
-            .await?;
+            .await;
+            finish_client_run(result, cancel, metrics_task).await?;
         }
         Command::ReadAccountsRun {
             read_accounts,
@@ -102,14 +114,20 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
             execution_params,
         } => {
             let accounts = read_accounts_file(read_accounts.accounts_file.clone());
-            run_client(
+            let cancel = CancellationToken::new();
+            let (stats_sender, stats_receiver) = oneshot::channel();
+            let metrics_task = spawn_metrics_reporter(stats_receiver, cancel.clone());
+            let result = run_client(
                 rpc_client,
                 websocket_url,
                 accounts,
                 transaction_params,
                 execution_params,
+                Some(stats_sender),
+                cancel.clone(),
             )
-            .await?;
+            .await;
+            finish_client_run(result, cancel, metrics_task).await?;
         }
         Command::WriteAccounts(write_accounts) => {
             create_file_persisted_accounts(
@@ -171,6 +189,94 @@ fn create_mock_accounts(num_payers: usize) -> AccountsFile {
     AccountsFile {
         payers: (0..num_payers).map(|_| Keypair::new()).collect(),
     }
+}
+
+fn spawn_metrics_reporter(
+    stats_receiver: oneshot::Receiver<RunClientStats>,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        match stats_receiver.await {
+            Ok(client_stats) => {
+                report_aggregated_stats(client_stats, METRICS_REPORTING_INTERVAL, cancel).await;
+            }
+            Err(_) => {
+                debug!("Stats reporter was not started because stats were not available.");
+            }
+        }
+    })
+}
+
+/// Periodically reads and resets stats from all scheduler instances, sums them,
+/// and reports the aggregate to InfluxDB under a single metric name.
+#[allow(clippy::arithmetic_side_effects)]
+async fn report_aggregated_stats(
+    client_stats: RunClientStats,
+    reporting_interval: Duration,
+    cancel: CancellationToken,
+) {
+    let mut interval = tokio::time::interval(reporting_interval);
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {
+                let (mut connect_error, mut connection_error, mut successfully_sent,
+                     mut congestion_events, mut write_error) = (0i64, 0i64, 0i64, 0i64, 0i64);
+                for stats in &client_stats.send_transaction_stats {
+                    let view = stats.read_and_reset();
+                    connect_error += (view.connect_error_cids_exhausted
+                        + view.connect_error_other
+                        + view.connect_error_invalid_remote_address) as i64;
+                    connection_error += (view.connection_error_reset
+                        + view.connection_error_cids_exhausted
+                        + view.connection_error_timed_out
+                        + view.connection_error_application_closed
+                        + view.connection_error_transport_error
+                        + view.connection_error_version_mismatch
+                        + view.connection_error_locally_closed) as i64;
+                    successfully_sent += view.successfully_sent as i64;
+                    congestion_events += view.transport_congestion_events as i64;
+                    write_error += (view.write_error_stopped
+                        + view.write_error_closed_stream
+                        + view.write_error_connection_lost
+                        + view.write_error_zero_rtt_rejected) as i64;
+                }
+                datapoint_info!(
+                    "transaction-bench-network",
+                    ("connect_error", connect_error, i64),
+                    ("connection_error", connection_error, i64),
+                    ("successfully_sent", successfully_sent, i64),
+                    ("congestion_events", congestion_events, i64),
+                    ("write_error", write_error, i64),
+                );
+
+                let (total_priority_fees, priority_fee_tx_count) =
+                    client_stats.priority_fee_stats.read_and_reset();
+                datapoint_info!(
+                    "transaction-bench-priority-fees",
+                    ("total_priority_fees", total_priority_fees, i64),
+                    ("tx_count", priority_fee_tx_count, i64),
+                );
+            }
+            _ = cancel.cancelled() => break,
+        }
+    }
+}
+
+async fn finish_client_run(
+    result: Result<(), BenchClientError>,
+    cancel: CancellationToken,
+    metrics_task: JoinHandle<()>,
+) -> Result<(), BenchClientError> {
+    cancel.cancel();
+    if let Err(err) = metrics_task.await {
+        error!("Stats reporting task panicked: {err:?}");
+        result?;
+        return Err(BenchClientError::TaskJoinFailure {
+            task_name: "StatsReporter".to_string(),
+            reason: err.to_string(),
+        });
+    }
+    result
 }
 
 #[cfg(test)]

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -8,7 +8,6 @@ use {
     },
     log::*,
     solana_keypair::Keypair,
-    solana_metrics::datapoint_info,
     solana_pubkey::Pubkey,
     solana_quic_definitions::{
         QUIC_MAX_STAKED_CONCURRENT_STREAMS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
@@ -30,7 +29,7 @@ use {
     },
     std::{fmt::Debug, num::NonZeroU64, sync::Arc, time::Duration},
     tokio::{
-        sync::{mpsc, watch},
+        sync::{mpsc, oneshot, watch},
         task::JoinHandle,
     },
     tokio_util::sync::CancellationToken,
@@ -45,13 +44,17 @@ const WORKER_CHANNEL_SIZE: usize = 20;
 /// doesn't affect TPS.
 const MAX_RECONNECT_ATTEMPTS: usize = 5;
 
-/// How often tpu-client-next reports network metrics.
-const METRICS_REPORTING_INTERVAL: Duration = Duration::from_secs(1);
-
 /// Default number of streams per connection if stake-based computation fails.
 /// This failure happens if we use stake overrides.
 const DEFAULT_NUM_STREAMS_PER_CONNECTION: usize = 8;
 const TARGET_BATCHES_PER_SECOND: u64 = 10;
+
+pub struct RunClientStats {
+    pub send_transaction_stats: Vec<Arc<SendTransactionStats>>,
+    pub priority_fee_stats: Arc<PriorityFeeStats>,
+}
+
+pub type RunClientStatsSender = oneshot::Sender<RunClientStats>;
 
 async fn find_node_activated_stake(
     rpc_client: &Arc<RpcClient>,
@@ -123,62 +126,6 @@ where
     }
 }
 
-/// Periodically reads and resets stats from all scheduler instances, sums them,
-/// and reports the aggregate to InfluxDB under a single metric name.
-#[allow(clippy::arithmetic_side_effects)]
-async fn report_aggregated_stats(
-    all_stats: Vec<Arc<SendTransactionStats>>,
-    priority_fee_stats: Arc<PriorityFeeStats>,
-    reporting_interval: Duration,
-    cancel: CancellationToken,
-) {
-    let mut interval = tokio::time::interval(reporting_interval);
-    loop {
-        tokio::select! {
-            _ = interval.tick() => {
-                let (mut connect_error, mut connection_error, mut successfully_sent,
-                     mut congestion_events, mut write_error) = (0i64, 0i64, 0i64, 0i64, 0i64);
-                for stats in &all_stats {
-                    let view = stats.read_and_reset();
-                    connect_error += (view.connect_error_cids_exhausted
-                        + view.connect_error_other
-                        + view.connect_error_invalid_remote_address) as i64;
-                    connection_error += (view.connection_error_reset
-                        + view.connection_error_cids_exhausted
-                        + view.connection_error_timed_out
-                        + view.connection_error_application_closed
-                        + view.connection_error_transport_error
-                        + view.connection_error_version_mismatch
-                        + view.connection_error_locally_closed) as i64;
-                    successfully_sent += view.successfully_sent as i64;
-                    congestion_events += view.transport_congestion_events as i64;
-                    write_error += (view.write_error_stopped
-                        + view.write_error_closed_stream
-                        + view.write_error_connection_lost
-                        + view.write_error_zero_rtt_rejected) as i64;
-                }
-                datapoint_info!(
-                    "transaction-bench-network",
-                    ("connect_error", connect_error, i64),
-                    ("connection_error", connection_error, i64),
-                    ("successfully_sent", successfully_sent, i64),
-                    ("congestion_events", congestion_events, i64),
-                    ("write_error", write_error, i64),
-                );
-
-                let (total_priority_fees, priority_fee_tx_count) =
-                    priority_fee_stats.read_and_reset();
-                datapoint_info!(
-                    "transaction-bench-priority-fees",
-                    ("total_priority_fees", total_priority_fees, i64),
-                    ("tx_count", priority_fee_tx_count, i64),
-                );
-            }
-            _ = cancel.cancelled() => break,
-        }
-    }
-}
-
 pub async fn run_client(
     rpc_client: Arc<RpcClient>,
     websocket_url: String,
@@ -196,6 +143,8 @@ pub async fn run_client(
         priority_fee_params,
         leader_tracker,
     }: ExecutionParams,
+    stats_sender: Option<RunClientStatsSender>,
+    cancel: CancellationToken,
 ) -> Result<(), BenchClientError> {
     let validator_identities: Vec<Keypair> = staked_identity_files
         .into_iter()
@@ -300,7 +249,6 @@ pub async fn run_client(
         workers_pull_size,
     );
 
-    let cancel = CancellationToken::new();
     let transaction_generator_task_handle =
         tokio::spawn(async move { transaction_generator.run().await });
     let config = LeaderTpuCacheServiceConfig {
@@ -361,13 +309,16 @@ pub async fn run_client(
         scheduler_handles.push(scheduler_handle);
     }
 
-    // Single metrics reporter aggregating stats across all tpu-client-next instances.
-    tokio::spawn(report_aggregated_stats(
-        all_stats,
-        priority_fee_stats,
-        METRICS_REPORTING_INTERVAL,
-        cancel,
-    ));
+    if let Some(stats_sender) = stats_sender
+        && stats_sender
+            .send(RunClientStats {
+                send_transaction_stats: all_stats,
+                priority_fee_stats,
+            })
+            .is_err()
+    {
+        debug!("Stats receiver has been dropped.");
+    }
 
     join_service(transaction_generator_task_handle, "TransactionGenerator").await?;
     join_service(blockhash_task_handle, "BlockhashUpdater").await?;

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -12,9 +12,12 @@ use {
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::{
         config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter},
-        response::{RpcBlockUpdateError, transaction::versioned::VersionedTransaction},
+        response::{
+            Response, RpcBlockUpdate, RpcBlockUpdateError,
+            transaction::versioned::VersionedTransaction,
+        },
     },
-    solana_sdk_ids::system_program,
+    solana_sdk_ids::{compute_budget, system_program},
     solana_signer::Signer,
     solana_test_validator::TestValidatorGenesis,
     solana_tpu_tools_common::{
@@ -30,10 +33,12 @@ use {
     },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
+        num::NonZeroU64,
         sync::Arc,
-        time::Duration,
+        time::{Duration, Instant},
     },
     tokio::runtime::Builder,
+    tokio_util::sync::CancellationToken,
 };
 
 #[test]
@@ -89,6 +94,8 @@ fn test_transactions_sending() {
     )
     .unwrap();
 
+    let cancel = CancellationToken::new();
+    let (stats_sender, stats_receiver) = tokio::sync::oneshot::channel();
     let handle = rt.spawn(async move {
         let funding_key = Keypair::new();
         let funding_pubkey = funding_key.pubkey();
@@ -100,8 +107,8 @@ fn test_transactions_sending() {
             .expect("Airdrop request should not fail.");
         wait_for_balance(rpc_client.as_ref(), &funding_pubkey, 100_000_000).await;
         let account_params = AccountParams {
-            num_payers: 16,
-            payer_account_balance: 1000,
+            num_payers: 25,
+            payer_account_balance: 1_000_000,
         };
 
         let accounts = create_ephemeral_accounts(
@@ -133,8 +140,8 @@ fn test_transactions_sending() {
             ExecutionParams {
                 staked_identity_files: vec![],
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
-                duration: Some(Duration::from_secs(5)),
-                target_tps: None,
+                duration: Some(Duration::from_secs(2)),
+                target_tps: Some(NonZeroU64::new(10).unwrap()),
                 num_max_open_connections: 1,
                 workers_pull_size: 1,
                 send_fanout: 1,
@@ -145,45 +152,46 @@ fn test_transactions_sending() {
                 },
                 leader_tracker: LeaderTracker::PinnedLeaderTracker { address: tpu_addr },
             },
+            Some(stats_sender),
+            cancel,
         )
         .await
     });
-
-    let mut num_txs = 0;
-    for _ in 0..10 {
-        receiver.try_iter().for_each(|response| {
-            if let Some(err) = response.value.err {
-                // sometimes block is not ready, see
-                // https://github.com/solana-labs/solana/issues/33462
-                assert_eq!(err, RpcBlockUpdateError::BlockStoreError);
-            }
-            if let Some(block) = response.value.block
-                && let Some(encoded_transactions) = block.transactions
-            {
-                for encoded_tx in encoded_transactions {
-                    let tx = encoded_tx.transaction.decode();
-                    // Transactions built by the bench contain:
-                    //   set_compute_unit_limit + set_compute_unit_price + transfer
-                    // for the single-instruction transfer case used here.
-                    if let Some(tx) = tx
-                        && is_transfer(&tx)
-                        && tx.message.instructions().len() == 3
-                    {
-                        num_txs += 1;
-                    }
-                }
-            }
-        });
-        std::thread::sleep(Duration::from_secs(1));
-    }
 
     rt.block_on(handle)
         .expect("Should not fail joining client task.")
         .expect("Should not fail running client.");
 
+    let client_stats = rt
+        .block_on(stats_receiver)
+        .expect("Should receive transaction send stats.");
+    let successfully_sent = client_stats
+        .send_transaction_stats
+        .iter()
+        .map(|stats| stats.to_non_atomic().successfully_sent)
+        .sum();
+    assert!(
+        successfully_sent > 0,
+        "Expected client to successfully send at least one transfer tx"
+    );
+
+    let mut num_txs = 0u64;
+    let before = Instant::now();
+    while num_txs < successfully_sent && before.elapsed() < Duration::from_secs(5) {
+        num_txs += count_transfer_txs(receiver.try_iter());
+        if num_txs < successfully_sent {
+            std::thread::sleep(Duration::from_millis(100));
+        }
+    }
+    num_txs += count_transfer_txs(receiver.try_iter());
+
+    // we cannot guarantee that all sent transactions will be included in a block within the test
+    // duration, because when transaction generator stops by duration it drops senders which leads
+    // to stopping also scheduler. So it might happen that stopped connection has some undelivered
+    // streams.
     assert!(
         num_txs > 0,
-        "Expected to receive >0 transfer txs but got {num_txs}"
+        "Expected to receive at least one transfer tx but got {num_txs}"
     );
 
     // If we don't drop the test_validator, the blocking web socket service
@@ -216,12 +224,43 @@ async fn wait_for_balance(client: &RpcClient, pubkey: &solana_pubkey::Pubkey, ta
     panic!("Airdrop balance did not reach target {target} for {pubkey}");
 }
 
+fn count_transfer_txs(responses: impl IntoIterator<Item = Response<RpcBlockUpdate>>) -> u64 {
+    let mut num_txs = 0u64;
+    for response in responses {
+        if let Some(err) = response.value.err {
+            // sometimes block is not ready, see
+            // https://github.com/solana-labs/solana/issues/33462
+            assert_eq!(err, RpcBlockUpdateError::BlockStoreError);
+        }
+        if let Some(block) = response.value.block
+            && let Some(encoded_transactions) = block.transactions
+        {
+            for encoded_tx in encoded_transactions {
+                let tx = encoded_tx.transaction.decode();
+                if let Some(tx) = tx
+                    && is_transfer(&tx)
+                {
+                    num_txs = num_txs.saturating_add(1);
+                }
+            }
+        }
+    }
+    num_txs
+}
+
 fn is_transfer(tx: &VersionedTransaction) -> bool {
     let message = &tx.message;
     let account_keys = message.static_account_keys();
+    let instructions = message.instructions();
 
-    message
-        .instructions()
-        .iter()
-        .any(|instruction| instruction.program_id(account_keys) == &system_program::id())
+    let Some((transfer_instruction, compute_budget_instructions)) = instructions.split_last()
+    else {
+        return false;
+    };
+
+    !compute_budget_instructions.is_empty()
+        && compute_budget_instructions
+            .iter()
+            .all(|instruction| instruction.program_id(account_keys) == &compute_budget::id())
+        && transfer_instruction.program_id(account_keys) == &system_program::id()
 }


### PR DESCRIPTION
### Problem
The problem is that current integration test is racy. It happens because we specify duration and how many txs to send per interval but it might actually happen that client didn't manage to send exactly duration/interval transactions for various reasons. 

### Solution

Proposed solution moves stats handling from run_client function to the main function. And in test we can check how many txs has been sent.