### PR TITLE
Implemented a hidden `--mock-rpc` mode for `transaction-bench` so it can be stress-tested against a mock QUIC server without requiring a valid RPC backend.

### DIFF
--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -62,6 +62,14 @@ pub struct ClientCliParameters {
     )]
     pub validate_accounts: bool,
 
+    #[clap(
+        long,
+        hide = true,
+        help = "Use the internal mock RpcClient for local stress testing against a mock QUIC \
+                server. Intended for testing only."
+    )]
+    pub mock_rpc: bool,
+
     #[clap(subcommand)]
     pub command: Command,
 }
@@ -430,6 +438,7 @@ mod tests {
             },
             authority: Some(PathBuf::from(&keypair_file_name)),
             validate_accounts: false,
+            mock_rpc: false,
         };
         let actual = ClientCliParameters::try_parse_from(args).unwrap();
 
@@ -483,6 +492,7 @@ mod tests {
             },
             authority: Some(PathBuf::from(&keypair_file_name)),
             validate_accounts: false,
+            mock_rpc: false,
         };
         let cli = ClientCliParameters::try_parse_from(args);
         assert!(cli.is_ok(), "Unexpected error {:?}", cli.err());
@@ -610,6 +620,7 @@ mod tests {
             }),
             authority: Some(PathBuf::from(&keypair_file_name)),
             validate_accounts: false,
+            mock_rpc: false,
         };
         let cli = ClientCliParameters::try_parse_from(args);
         assert!(cli.is_ok(), "Unexpected error {:?}", cli.err());
@@ -677,6 +688,27 @@ mod tests {
         // Scheduling with random max = 0 must be rejected: silently no-op
         // was the bug, see PR #56 review.
         assert!(PriorityFeeMode::try_from(&params(0, Some(5))).is_err());
+    }
+
+    #[test]
+    fn test_mock_rpc_flag() {
+        let keypair_file_name = "/home/testUser/masterKey.json";
+
+        let mut args = vec![
+            "test",
+            "--mock-rpc",
+            "-ul",
+            "--authority",
+            keypair_file_name,
+            "run",
+        ];
+        let (account_args, _account_params) = get_common_account_params();
+        args.extend(account_args.iter());
+        let (exec_args, _execution_params) = get_common_execution_params(keypair_file_name);
+        args.extend(exec_args.iter());
+
+        let actual = ClientCliParameters::try_parse_from(args).unwrap();
+        assert!(actual.mock_rpc);
     }
 
     /// Check that cannot use `write` subcommand together with parameters from `TransactionParams`

--- a/transaction-bench/src/lib.rs
+++ b/transaction-bench/src/lib.rs
@@ -2,5 +2,6 @@ pub mod backpressured_broadcaster;
 pub mod cli;
 pub mod error;
 pub mod generator;
+pub mod mock_rpc_client;
 pub mod priority_fee;
 pub mod run_client;

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -170,3 +170,101 @@ fn create_mock_accounts(num_payers: usize) -> AccountsFile {
         payers: (0..num_payers).map(|_| Keypair::new()).collect(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        solana_commitment_config::CommitmentConfig,
+        solana_transaction_bench::cli::{
+            ExecutionParams, InstructionPaddingParams, PriorityFeeParams, SimpleTransferTxParams,
+            TransactionParams,
+        },
+        std::net::{IpAddr, Ipv4Addr, SocketAddr},
+        tools_common::cli::{AccountParams, WriteAccounts},
+    };
+
+    fn test_run_parameters(leader_tracker: LeaderTracker) -> ClientCliParameters {
+        ClientCliParameters {
+            json_rpc_url: "http://localhost:8899".to_string(),
+            commitment_config: CommitmentConfig::confirmed(),
+            authority: None,
+            validate_accounts: false,
+            mock_rpc: true,
+            command: Command::Run {
+                account_params: AccountParams {
+                    num_payers: 4,
+                    payer_account_balance: 1_000,
+                },
+                execution_params: ExecutionParams {
+                    staked_identity_files: vec![],
+                    bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 0),
+                    duration: None,
+                    target_tps: None,
+                    num_max_open_connections: 1,
+                    workers_pull_size: 1,
+                    send_fanout: 1,
+                    compute_unit_price: None,
+                    priority_fee_params: PriorityFeeParams {
+                        random_compute_unit_price_max: 0,
+                        priority_fee_schedule_period_ms: None,
+                    },
+                    leader_tracker,
+                },
+                transaction_params: TransactionParams {
+                    simple_transfer_tx_params: SimpleTransferTxParams {
+                        lamports_to_transfer: 513,
+                        transfer_tx_cu_budget: 600,
+                        num_send_instructions_per_tx: 1,
+                        tx_batch_size: None,
+                        num_conflict_groups: None,
+                    },
+                    padding_params: InstructionPaddingParams {
+                        instruction_padding_data_size: None,
+                        instruction_padding_program_id: None,
+                    },
+                    use_txv1: false,
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn test_mock_rpc_requires_pinned_leader_tracker() {
+        let parameters = test_run_parameters(LeaderTracker::WsLeaderTracker);
+
+        let err = validate_mock_rpc_usage(&parameters)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("pinned-leader-tracker"));
+    }
+
+    #[test]
+    fn test_mock_rpc_rejects_write_accounts() {
+        let parameters = ClientCliParameters {
+            json_rpc_url: "http://localhost:8899".to_string(),
+            commitment_config: CommitmentConfig::confirmed(),
+            authority: None,
+            validate_accounts: false,
+            mock_rpc: true,
+            command: Command::WriteAccounts(WriteAccounts {
+                accounts_file: "accounts.json".into(),
+                account_params: AccountParams {
+                    num_payers: 4,
+                    payer_account_balance: 1_000,
+                },
+            }),
+        };
+
+        let err = validate_mock_rpc_usage(&parameters)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("write-accounts"));
+    }
+
+    #[test]
+    fn test_create_mock_accounts_generates_requested_number_of_payers() {
+        let accounts = create_mock_accounts(3);
+        assert_eq!(accounts.payers.len(), 3);
+    }
+}

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -6,14 +6,17 @@ use {
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::{EncodableKey, Signer},
     solana_tpu_tools_common::accounts_file::{
-        create_ephemeral_accounts, create_file_persisted_accounts, read_accounts_file,
+        AccountsFile, create_ephemeral_accounts, create_file_persisted_accounts,
+        read_accounts_file,
     },
     solana_transaction_bench::{
         cli::{ClientCliParameters, Command, build_cli_parameters},
         error::BenchClientError,
+        mock_rpc_client::new_mock_rpc_client,
         run_client::run_client,
     },
     std::sync::Arc,
+    tools_common::cli::LeaderTracker,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -37,6 +40,8 @@ fn main() {
 
 #[tokio::main]
 async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
+    validate_mock_rpc_usage(&parameters)?;
+
     let authority = if let Some(authority_file) = parameters.authority {
         Keypair::read_from_file(authority_file)
             .map_err(|_err| BenchClientError::KeypairReadFailure)?
@@ -49,10 +54,14 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
     let (_, websocket_url) =
         ConfigInput::compute_websocket_url_setting("", "", &parameters.json_rpc_url, "");
 
-    let rpc_client = Arc::new(RpcClient::new_with_commitment(
-        parameters.json_rpc_url.to_string(),
-        parameters.commitment_config,
-    ));
+    let rpc_client = Arc::new(if parameters.mock_rpc {
+        new_mock_rpc_client(parameters.commitment_config)
+    } else {
+        RpcClient::new_with_commitment(
+            parameters.json_rpc_url.to_string(),
+            parameters.commitment_config,
+        )
+    });
 
     match parameters.command {
         Command::Run {
@@ -60,14 +69,22 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
             account_params,
             execution_params,
         } => {
-            let accounts = create_ephemeral_accounts(
-                rpc_client.clone(),
-                authority,
-                account_params.num_payers,
-                account_params.payer_account_balance,
-                parameters.validate_accounts,
-            )
-            .await?;
+            let accounts = if parameters.mock_rpc {
+                info!(
+                    "Skipping payer account creation because --mock-rpc is enabled; generating \
+                     local ephemeral payers instead."
+                );
+                create_mock_accounts(account_params.num_payers)
+            } else {
+                create_ephemeral_accounts(
+                    rpc_client.clone(),
+                    authority,
+                    account_params.num_payers,
+                    account_params.payer_account_balance,
+                    parameters.validate_accounts,
+                )
+                .await?
+            };
             run_client(
                 rpc_client,
                 websocket_url,
@@ -106,4 +123,50 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
     }
 
     Ok(())
+}
+
+fn validate_mock_rpc_usage(parameters: &ClientCliParameters) -> Result<(), BenchClientError> {
+    if !parameters.mock_rpc {
+        return Ok(());
+    }
+
+    if parameters.validate_accounts {
+        return Err(BenchClientError::InvalidCliArguments(
+            "--mock-rpc does not support --validate-accounts".to_string(),
+        ));
+    }
+
+    let requires_pinned = matches!(
+        &parameters.command,
+        Command::Run {
+            execution_params,
+            ..
+        } | Command::ReadAccountsRun {
+            execution_params,
+        ..
+        } if !matches!(
+            &execution_params.leader_tracker,
+            LeaderTracker::PinnedLeaderTracker { .. }
+        )
+    );
+
+    if requires_pinned {
+        return Err(BenchClientError::InvalidCliArguments(
+            "--mock-rpc requires `pinned-leader-tracker`".to_string(),
+        ));
+    }
+
+    if matches!(&parameters.command, Command::WriteAccounts(_)) {
+        return Err(BenchClientError::InvalidCliArguments(
+            "--mock-rpc does not support `write-accounts`".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+fn create_mock_accounts(num_payers: usize) -> AccountsFile {
+    AccountsFile {
+        payers: (0..num_payers).map(|_| Keypair::new()).collect(),
+    }
 }

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -5,9 +5,12 @@ use {
     solana_keypair::Keypair,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::{EncodableKey, Signer},
-    solana_tpu_tools_common::accounts_file::{
-        AccountsFile, create_ephemeral_accounts, create_file_persisted_accounts,
-        read_accounts_file,
+    solana_tpu_tools_common::{
+        accounts_file::{
+            AccountsFile, create_ephemeral_accounts, create_file_persisted_accounts,
+            read_accounts_file,
+        },
+        cli::LeaderTracker,
     },
     solana_transaction_bench::{
         cli::{ClientCliParameters, Command, build_cli_parameters},
@@ -16,7 +19,6 @@ use {
         run_client::run_client,
     },
     std::sync::Arc,
-    tools_common::cli::LeaderTracker,
 };
 
 #[cfg(not(any(target_env = "msvc", target_os = "freebsd")))]
@@ -176,12 +178,12 @@ mod tests {
     use {
         super::*,
         solana_commitment_config::CommitmentConfig,
+        solana_tpu_tools_common::cli::{AccountParams, WriteAccounts},
         solana_transaction_bench::cli::{
             ExecutionParams, InstructionPaddingParams, PriorityFeeParams, SimpleTransferTxParams,
             TransactionParams,
         },
         std::net::{IpAddr, Ipv4Addr, SocketAddr},
-        tools_common::cli::{AccountParams, WriteAccounts},
     };
 
     fn test_run_parameters(leader_tracker: LeaderTracker) -> ClientCliParameters {

--- a/transaction-bench/src/mock_rpc_client.rs
+++ b/transaction-bench/src/mock_rpc_client.rs
@@ -1,0 +1,130 @@
+use {
+    async_trait::async_trait,
+    serde_json::{json, to_value},
+    solana_commitment_config::CommitmentConfig,
+    solana_rpc_client::{
+        mock_sender::MockSender,
+        nonblocking::rpc_client::RpcClient,
+        rpc_client::RpcClientConfig,
+        rpc_sender::{RpcSender, RpcTransportStats},
+    },
+    solana_rpc_client_api::{
+        client_error::Result as ClientResult,
+        request::RpcRequest,
+        response::{Response, RpcBlockhash, RpcResponseContext},
+    },
+    solana_sha256_hasher::hash,
+    solana_sdk_ids::system_program,
+    std::sync::atomic::{AtomicU64, Ordering},
+};
+
+pub fn new_mock_rpc_client(commitment_config: CommitmentConfig) -> RpcClient {
+    RpcClient::new_sender(
+        TransactionBenchMockSender::default(),
+        RpcClientConfig::with_commitment(commitment_config),
+    )
+}
+
+struct TransactionBenchMockSender {
+    inner: MockSender,
+    blockhash_counter: AtomicU64,
+}
+
+impl Default for TransactionBenchMockSender {
+    fn default() -> Self {
+        Self {
+            inner: MockSender::new("succeeds"),
+            blockhash_counter: AtomicU64::new(0),
+        }
+    }
+}
+
+#[async_trait]
+impl RpcSender for TransactionBenchMockSender {
+    fn get_transport_stats(&self) -> RpcTransportStats {
+        self.inner.get_transport_stats()
+    }
+
+    async fn send(
+        &self,
+        request: RpcRequest,
+        params: serde_json::Value,
+    ) -> ClientResult<serde_json::Value> {
+        if request == RpcRequest::GetLatestBlockhash {
+            let next = self.blockhash_counter.fetch_add(1, Ordering::Relaxed);
+            let blockhash = hash(&next.to_le_bytes());
+            return to_value(Response {
+                context: RpcResponseContext {
+                    slot: next,
+                    api_version: None,
+                },
+                value: RpcBlockhash {
+                    blockhash: blockhash.to_string(),
+                    last_valid_block_height: next.saturating_add(150),
+                },
+            })
+            .map_err(Into::into);
+        }
+
+        if request == RpcRequest::GetAccountInfo {
+            return Ok(json!(Response {
+                context: RpcResponseContext {
+                    slot: 1,
+                    api_version: None,
+                },
+                value: {
+                    "data": ["", "base64"],
+                    "executable": false,
+                    "lamports": 1,
+                    "owner": system_program::id().to_string(),
+                    "rentEpoch": 0,
+                    "space": 0,
+                },
+            }));
+        }
+
+        self.inner.send(request, params).await
+    }
+
+    fn url(&self) -> String {
+        "transaction-bench-mock-rpc".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+    };
+
+    #[tokio::test]
+    async fn test_mock_rpc_client_returns_changing_blockhashes() {
+        let rpc_client = new_mock_rpc_client(CommitmentConfig::confirmed());
+
+        let first = rpc_client.get_latest_blockhash().await.unwrap();
+        let second = rpc_client.get_latest_blockhash().await.unwrap();
+
+        assert_ne!(first, second);
+    }
+
+    #[tokio::test]
+    async fn test_mock_rpc_client_delegates_other_requests() {
+        let rpc_client = new_mock_rpc_client(CommitmentConfig::confirmed());
+
+        let balance = rpc_client.get_balance(&solana_pubkey::Pubkey::new_unique()).await;
+
+        assert!(balance.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_mock_rpc_client_returns_account_info() {
+        let rpc_client = new_mock_rpc_client(CommitmentConfig::confirmed());
+
+        let account = rpc_client
+            .get_account(&solana_pubkey::Pubkey::new_unique())
+            .await
+            .unwrap();
+
+        assert_eq!(account.lamports, 1);
+    }
+}

--- a/transaction-bench/src/mock_rpc_client.rs
+++ b/transaction-bench/src/mock_rpc_client.rs
@@ -14,7 +14,6 @@ use {
         response::{Response, RpcBlockhash, RpcResponseContext},
     },
     solana_sha256_hasher::hash,
-    solana_sdk_ids::system_program,
     std::sync::atomic::{AtomicU64, Ordering},
 };
 
@@ -72,14 +71,14 @@ impl RpcSender for TransactionBenchMockSender {
                     slot: 1,
                     api_version: None,
                 },
-                value: {
+                value: json!({
                     "data": ["", "base64"],
                     "executable": false,
                     "lamports": 1,
-                    "owner": system_program::id().to_string(),
+                    "owner": "11111111111111111111111111111111",
                     "rentEpoch": 0,
                     "space": 0,
-                },
+                }),
             }));
         }
 
@@ -93,9 +92,7 @@ impl RpcSender for TransactionBenchMockSender {
 
 #[cfg(test)]
 mod tests {
-    use {
-        super::*,
-    };
+    use super::*;
 
     #[tokio::test]
     async fn test_mock_rpc_client_returns_changing_blockhashes() {
@@ -111,7 +108,9 @@ mod tests {
     async fn test_mock_rpc_client_delegates_other_requests() {
         let rpc_client = new_mock_rpc_client(CommitmentConfig::confirmed());
 
-        let balance = rpc_client.get_balance(&solana_pubkey::Pubkey::new_unique()).await;
+        let balance = rpc_client
+            .get_balance(&solana_pubkey::Pubkey::new_unique())
+            .await;
 
         assert!(balance.is_ok());
     }


### PR DESCRIPTION
Implemented a hidden `--mock-rpc` mode for `transaction-bench` so it can be stress-tested against a mock QUIC server without requiring a valid RPC backend.

Changes:
- added hidden `--mock-rpc` CLI flag
- added a custom mock RPC client that delegates to Solana’s mock sender
- overridden `getLatestBlockhash` to return changing hashes so the blockhash updater does not stall
- overridden `getAccountInfo` to return a dummy account for RPC-dependent checks
- restricted mock RPC mode to `pinned-leader-tracker`

Validation:
- `cargo +nightly-2025-12-05 fmt --all`
- `cargo +nightly-2025-12-05 sort --workspace`
- `cargo +nightly-2025-12-05 check --locked --workspace --all-targets`
- `cargo +nightly-2025-12-05 clippy --workspace --all-targets -- --deny=warnings --deny=clippy::default_trait_access --deny=clippy::arithmetic_side_effects --deny=clippy::manual_let_else --deny=clippy::uninlined-format-args --deny=clippy::used_underscore_binding`

Part of #51