### PR TITLE
remove codeowners

### DIFF
--- a/.github/codeowners
+++ b/.github/codeowners
@@ -1,2 +1,0 @@
-# Please keep this file sorted
-* @KirillLykov


### PR DESCRIPTION
#### Problem

I've integrated the shared rulesets into this repo which including a rule that requires `CODEOWNERS` approval for PRs.

#### Summary of Changes

I think we can either remove that rule or update the `CODEOWNERS` file. in the past, I believe anyone with write permission could approve and merge PRs. maybe we should keep the rule and just remove the outdated `CODEOWNERS`