### PR TITLE
fix description in Cargo.toml

### DIFF
--- a/transaction-bench/Cargo.toml
+++ b/transaction-bench/Cargo.toml
@@ -5,6 +5,10 @@ authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }
 license = { workspace = true }
+description = "Load-generation benchmark tool for sending Solana transfer transactions over TPU QUIC."
+readme = "README.md"
+keywords = ["solana", "tpu", "benchmark"]
+categories = ["command-line-utilities", "development-tools"]
 edition = { workspace = true }
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
This PR is to fix the problem with publishing.
Attempt to publish transaction-bench failed with the following error:
```
Run cargo publish -p "${CRATE_NAME}"
    Updating crates.io index
warning: manifest has no description
  |
  = note: see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info
   Packaging solana-transaction-bench v0.1.0 (/home/runner/work/tpu-tools/tpu-tools/transaction-bench)
    Updating crates.io index
warning: package `keccak v0.1.5` in Cargo.lock is yanked in registry `crates-io`, consider updating to a version that is not yanked
    Packaged 18 files, 420.0KiB (97.3KiB compressed)
   Verifying solana-transaction-bench v0.1.0 (/home/runner/work/tpu-tools/tpu-tools/transaction-bench)
   Compiling solana-transaction-bench v0.1.0 (/home/runner/work/tpu-tools/tpu-tools/target/package/solana-transaction-bench-0.1.0)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 5.03s
   Uploading solana-transaction-bench v0.1.0 (/home/runner/work/tpu-tools/tpu-tools/transaction-bench)
error: failed to publish solana-transaction-bench v0.1.0 to registry at https://crates.io/
```