### PR TITLE
Add load-testing CLI flags to transaction-bench

### DIFF
--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -124,6 +124,14 @@ pub struct ExecutionParams {
     #[clap(
         long,
         value_parser = value_parser!(NonZeroU64),
+        help = "If specified, limits the benchmark to sending this many transactions. May be \
+                combined with --duration; whichever limit is reached first stops the run."
+    )]
+    pub num_transactions: Option<NonZeroU64>,
+
+    #[clap(
+        long,
+        value_parser = value_parser!(NonZeroU64),
         help = "Optional global target send rate in transactions per second. When set, \
                 transaction-bench switches to paced sending."
     )]
@@ -371,6 +379,7 @@ mod tests {
                 staked_identity_files: vec![PathBuf::from(&keypair_file_name)],
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 0),
                 duration: Some(Duration::from_secs(120)),
+                num_transactions: None,
                 target_tps: None,
                 leader_tracker: LeaderTracker::PinnedLeaderTracker {
                     address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8009),

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -139,6 +139,16 @@ pub struct ExecutionParams {
 
     #[clap(
         long,
+        value_parser = value_parser!(NonZeroU64),
+        help = "Override the QUIC initial congestion window (in bytes) passed to tpu-client-next. \
+                Larger values skip TCP-style slow-start at connection startup so that \
+                transactions can be sent as fast as possible immediately. Defaults to \
+                tpu-client-next's built-in value (128 * PACKET_DATA_SIZE)."
+    )]
+    pub initial_congestion_window: Option<NonZeroU64>,
+
+    #[clap(
+        long,
         default_value_t = 16,
         help = "Max number of connections to keep open."
     )]
@@ -381,6 +391,7 @@ mod tests {
                 duration: Some(Duration::from_secs(120)),
                 num_transactions: None,
                 target_tps: None,
+                initial_congestion_window: None,
                 leader_tracker: LeaderTracker::PinnedLeaderTracker {
                     address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8009),
                 },

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -149,6 +149,16 @@ pub struct ExecutionParams {
 
     #[clap(
         long,
+        default_value_t = 10,
+        help = "Max time (seconds) the client waits after generation finishes for the in-flight \
+                tx queues + quinn buffers to drain before tearing down the schedulers. Set to 0 \
+                to disable the drain phase (matches pre-drain behaviour and is likely to drop \
+                in-flight transactions when --num-transactions is set)."
+    )]
+    pub drain_seconds: u64,
+
+    #[clap(
+        long,
         default_value_t = 16,
         help = "Max number of connections to keep open."
     )]
@@ -403,6 +413,7 @@ mod tests {
                 num_transactions: None,
                 target_tps: None,
                 initial_congestion_window: None,
+                drain_seconds: 10,
                 leader_tracker: LeaderTracker::PinnedLeaderTracker {
                     address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8009),
                 },

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -156,6 +156,17 @@ pub struct ExecutionParams {
 
     #[clap(
         long,
+        default_value_t = 1,
+        help = "Number of tpu-client-next instances to spawn per staked identity. Because each \
+                instance opens one QUIC connection per leader, this is the number of connections \
+                per leader opened under one identity, without having to repeat \
+                --staked-identity-file. With no identity file, spawns this many unstaked \
+                instances. Total instances = max(1, num staked identities) * clients-per-identity."
+    )]
+    pub clients_per_identity: usize,
+
+    #[clap(
+        long,
         default_value_t = 8,
         help = "Size of the workers pull, controls how many transactions batches are generated in \
                 parallel."
@@ -396,6 +407,7 @@ mod tests {
                     address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8009),
                 },
                 num_max_open_connections: 16,
+                clients_per_identity: 1,
                 workers_pull_size: 8,
                 send_fanout: 2,
                 compute_unit_price: Some(1000),

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -42,6 +42,7 @@ pub struct TransactionGenerator {
     priority_fee_stats: Arc<PriorityFeeStats>,
     send_batch_size: usize,
     run_duration: Option<Duration>,
+    num_transactions: Option<NonZeroU64>,
     target_tps: Option<NonZeroU64>,
     workers_pull_size: usize,
 }
@@ -58,6 +59,7 @@ impl TransactionGenerator {
         priority_fee_stats: Arc<PriorityFeeStats>,
         send_batch_size: usize,
         duration: Option<Duration>,
+        num_transactions: Option<NonZeroU64>,
         target_tps: Option<NonZeroU64>,
         workers_pull_size: usize,
     ) -> Self {
@@ -71,6 +73,7 @@ impl TransactionGenerator {
             priority_fee_stats,
             send_batch_size,
             run_duration: duration,
+            num_transactions,
             target_tps,
             workers_pull_size,
         }
@@ -107,11 +110,21 @@ impl TransactionGenerator {
         let mut sender_index: usize = 0;
         let start = Instant::now();
         let mut next_batch_at = self.target_tps.map(|_| start);
+        let num_transactions_budget = self.num_transactions.map(|n| n.get());
+        let mut txs_scheduled: u64 = 0;
         loop {
             if let Some(run_duration) = self.run_duration
                 && start.elapsed() >= run_duration
             {
-                info!("Transaction generator is stopping...");
+                info!("Transaction generator is stopping: duration reached.");
+                while let Some(result) = futures.join_next().await {
+                    debug!("Future result {result:?}");
+                }
+                break;
+            }
+
+            if num_transactions_budget.is_some_and(|budget| txs_scheduled >= budget) {
+                info!("Transaction generator is stopping: requested tx count reached.");
                 while let Some(result) = futures.join_next().await {
                     debug!("Future result {result:?}");
                 }
@@ -127,7 +140,18 @@ impl TransactionGenerator {
                 if let Some(next_batch_deadline) = next_batch_at {
                     tokio::time::sleep_until(next_batch_deadline).await;
                 }
-                let send_batch_size = self.send_batch_size;
+                let send_batch_size = match num_transactions_budget {
+                    Some(budget) => {
+                        let remaining = budget.saturating_sub(txs_scheduled);
+                        if remaining == 0 {
+                            break;
+                        }
+                        let remaining = usize::try_from(remaining).unwrap_or(usize::MAX);
+                        self.send_batch_size.min(remaining)
+                    }
+                    None => self.send_batch_size,
+                };
+                txs_scheduled = txs_scheduled.saturating_add(send_batch_size as u64);
                 let transaction_params = self.transaction_params.clone();
                 let compute_unit_price = self.compute_unit_price;
                 let priority_fee_mode = self.priority_fee_mode.clone();

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -192,6 +192,7 @@ pub async fn run_client(
         target_tps,
         initial_congestion_window,
         num_max_open_connections,
+        clients_per_identity,
         workers_pull_size,
         send_fanout,
         compute_unit_price,
@@ -205,7 +206,13 @@ pub async fn run_client(
             Keypair::read_from_file(&path).map_err(|_err| BenchClientError::KeypairReadFailure)
         })
         .collect::<Result<_, _>>()?;
-    let num_tpu_clients = validator_identities.len().max(1);
+    // Each tpu-client-next instance opens one connection per leader. To get
+    // multiple connections under a single identity (without repeating
+    // --staked-identity-file), spawn `clients_per_identity` instances per
+    // identity. With no identity file, `num_identities` is 1 and these are
+    // unstaked instances.
+    let num_identities = validator_identities.len().max(1);
+    let num_tpu_clients = num_identities.saturating_mul(clients_per_identity.max(1));
 
     // Set up size of the txs batch to put into the queue to be equal to the num_streams_per_connection
     let num_streams_per_connection = compute_num_streams(
@@ -329,7 +336,9 @@ pub async fn run_client(
         )
         .await?;
 
-        let stake_identity = validator_identities.get(i).map(StakeIdentity::new);
+        let stake_identity = validator_identities
+            .get(i % num_identities)
+            .map(StakeIdentity::new);
         let scheduler_config = ConnectionWorkersSchedulerConfig {
             bind: BindTarget::Address(bind),
             stake_identity,

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -188,6 +188,7 @@ pub async fn run_client(
         staked_identity_files,
         bind,
         duration,
+        num_transactions,
         target_tps,
         num_max_open_connections,
         workers_pull_size,
@@ -296,6 +297,7 @@ pub async fn run_client(
         priority_fee_stats.clone(),
         send_batch_size,
         duration,
+        num_transactions,
         target_tps,
         workers_pull_size,
     );

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -28,7 +28,15 @@ use {
         accounts_file::AccountsFile, blockhash_updater::BlockhashUpdater,
         leader_updater::create_leader_updater,
     },
-    std::{fmt::Debug, num::NonZeroU64, sync::Arc, time::Duration},
+    std::{
+        fmt::Debug,
+        num::NonZeroU64,
+        sync::{
+            Arc,
+            atomic::{AtomicU64, Ordering},
+        },
+        time::Duration,
+    },
     tokio::{
         sync::{mpsc, watch},
         task::JoinHandle,
@@ -125,11 +133,18 @@ where
 
 /// Periodically reads and resets stats from all scheduler instances, sums them,
 /// and reports the aggregate to InfluxDB under a single metric name.
+///
+/// `successfully_sent_total` accumulates a non-resetting view of the
+/// `successfully_sent` counter across all instances so the drain phase can
+/// observe stability without fighting the per-tick reset.
 #[allow(clippy::arithmetic_side_effects)]
 async fn report_aggregated_stats(
     all_stats: Vec<Arc<SendTransactionStats>>,
     priority_fee_stats: Arc<PriorityFeeStats>,
     reporting_interval: Duration,
+    successfully_sent_total: Arc<AtomicU64>,
+    congestion_events_total: Arc<AtomicU64>,
+    write_error_total: Arc<AtomicU64>,
     cancel: CancellationToken,
 ) {
     let mut interval = tokio::time::interval(reporting_interval);
@@ -138,11 +153,23 @@ async fn report_aggregated_stats(
             _ = interval.tick() => {
                 let (mut connect_error, mut connection_error, mut successfully_sent,
                      mut congestion_events, mut write_error) = (0i64, 0i64, 0i64, 0i64, 0i64);
+                let (mut ce_reset, mut ce_cids, mut ce_timed_out, mut ce_app_closed,
+                     mut ce_transport, mut ce_version, mut ce_locally_closed) =
+                    (0u64, 0u64, 0u64, 0u64, 0u64, 0u64, 0u64);
+                let (mut we_stopped, mut we_closed_stream, mut we_conn_lost,
+                     mut we_zero_rtt) = (0u64, 0u64, 0u64, 0u64);
                 for stats in &all_stats {
                     let view = stats.read_and_reset();
                     connect_error += (view.connect_error_cids_exhausted
                         + view.connect_error_other
                         + view.connect_error_invalid_remote_address) as i64;
+                    ce_reset += view.connection_error_reset;
+                    ce_cids += view.connection_error_cids_exhausted;
+                    ce_timed_out += view.connection_error_timed_out;
+                    ce_app_closed += view.connection_error_application_closed;
+                    ce_transport += view.connection_error_transport_error;
+                    ce_version += view.connection_error_version_mismatch;
+                    ce_locally_closed += view.connection_error_locally_closed;
                     connection_error += (view.connection_error_reset
                         + view.connection_error_cids_exhausted
                         + view.connection_error_timed_out
@@ -152,10 +179,46 @@ async fn report_aggregated_stats(
                         + view.connection_error_locally_closed) as i64;
                     successfully_sent += view.successfully_sent as i64;
                     congestion_events += view.transport_congestion_events as i64;
+                    we_stopped += view.write_error_stopped;
+                    we_closed_stream += view.write_error_closed_stream;
+                    we_conn_lost += view.write_error_connection_lost;
+                    we_zero_rtt += view.write_error_zero_rtt_rejected;
                     write_error += (view.write_error_stopped
                         + view.write_error_closed_stream
                         + view.write_error_connection_lost
                         + view.write_error_zero_rtt_rejected) as i64;
+                }
+                let sent_total = successfully_sent_total
+                    .fetch_add(successfully_sent as u64, Ordering::Relaxed)
+                    + successfully_sent as u64;
+                let cong_total = congestion_events_total
+                    .fetch_add(congestion_events as u64, Ordering::Relaxed)
+                    + congestion_events as u64;
+                let werr_total = write_error_total
+                    .fetch_add(write_error as u64, Ordering::Relaxed)
+                    + write_error as u64;
+                info!(
+                    "tx-bench stats (last {}ms): sent={successfully_sent} \
+                     congestion_events={congestion_events} write_error={write_error} \
+                     connect_error={connect_error} connection_error={connection_error} \
+                     | totals: sent={sent_total} congestion_events={cong_total} \
+                     write_error={werr_total}",
+                    reporting_interval.as_millis(),
+                );
+                if connection_error > 0 {
+                    info!(
+                        "  connection_error breakdown: reset={ce_reset} \
+                         timed_out={ce_timed_out} application_closed={ce_app_closed} \
+                         transport_error={ce_transport} cids_exhausted={ce_cids} \
+                         version_mismatch={ce_version} locally_closed={ce_locally_closed}",
+                    );
+                }
+                if write_error > 0 {
+                    info!(
+                        "  write_error breakdown: stopped={we_stopped} \
+                         closed_stream={we_closed_stream} connection_lost={we_conn_lost} \
+                         zero_rtt_rejected={we_zero_rtt}",
+                    );
                 }
                 datapoint_info!(
                     "transaction-bench-network",
@@ -179,6 +242,56 @@ async fn report_aggregated_stats(
     }
 }
 
+/// After the generator finishes, give tpu-client-next's worker mpsc queues and
+/// quinn send buffers a chance to flush before the schedulers tear themselves
+/// down. Returns once `successfully_sent_total` is stable across two
+/// consecutive reporter ticks, then sleeps a short fixed tail to let quinn
+/// flush bytes already handed to it.
+///
+/// `drain_timeout` is the hard wall-clock cap — the tail is clamped to the
+/// remaining budget so total time never exceeds it.
+async fn drain_in_flight(
+    successfully_sent_total: Arc<AtomicU64>,
+    reporting_interval: Duration,
+    drain_timeout: Duration,
+    tail_after_stable: Duration,
+) {
+    let start = tokio::time::Instant::now();
+    // Sleep two reporting intervals between checks so the reporter has at
+    // least one tick to flush any outstanding successfully_sent counts.
+    let stability_interval = reporting_interval.saturating_mul(2);
+    let mut last_total = successfully_sent_total.load(Ordering::Relaxed);
+    loop {
+        let remaining = drain_timeout.saturating_sub(start.elapsed());
+        if remaining.is_zero() {
+            warn!(
+                "Drain phase hit the {drain_timeout:?} timeout; \
+                 successfully_sent={last_total}. Tearing down anyway."
+            );
+            return;
+        }
+        let sleep_for = stability_interval.min(remaining);
+        tokio::time::sleep(sleep_for).await;
+        let now_total = successfully_sent_total.load(Ordering::Relaxed);
+        if now_total == last_total {
+            let remaining = drain_timeout.saturating_sub(start.elapsed());
+            let tail = tail_after_stable.min(remaining);
+            info!(
+                "Drain phase reached stability at successfully_sent={last_total} after \
+                 {elapsed:?}; sleeping tail {tail:?} (cap {drain_timeout:?}).",
+                elapsed = start.elapsed(),
+            );
+            tokio::time::sleep(tail).await;
+            return;
+        }
+        last_total = now_total;
+    }
+}
+
+/// Fixed tail wait after stats stop growing. Lets quinn finish flushing bytes
+/// that were already written to its send buffer.
+const DRAIN_TAIL_AFTER_STABLE: Duration = Duration::from_secs(1);
+
 pub async fn run_client(
     rpc_client: Arc<RpcClient>,
     websocket_url: String,
@@ -191,6 +304,7 @@ pub async fn run_client(
         num_transactions,
         target_tps,
         initial_congestion_window,
+        drain_seconds,
         num_max_open_connections,
         clients_per_identity,
         workers_pull_size,
@@ -292,6 +406,11 @@ pub async fn run_client(
         transaction_receivers.push(receiver);
     }
 
+    // Extra sender clones kept alive past the generator so that the schedulers
+    // don't see `None` (and start tearing down workers) until after the drain
+    // phase has had a chance to flush in-flight queues.
+    let drain_senders: Vec<mpsc::Sender<_>> = transaction_senders.clone();
+
     let priority_fee_mode = PriorityFeeMode::try_from(&priority_fee_params)
         .map_err(BenchClientError::InvalidCliArguments)?;
     let priority_fee_stats = Arc::new(PriorityFeeStats::default());
@@ -374,19 +493,47 @@ pub async fn run_client(
     }
 
     // Single metrics reporter aggregating stats across all tpu-client-next instances.
+    let successfully_sent_total = Arc::new(AtomicU64::new(0));
+    let congestion_events_total = Arc::new(AtomicU64::new(0));
+    let write_error_total = Arc::new(AtomicU64::new(0));
     tokio::spawn(report_aggregated_stats(
         all_stats,
         priority_fee_stats,
         METRICS_REPORTING_INTERVAL,
+        successfully_sent_total.clone(),
+        congestion_events_total.clone(),
+        write_error_total.clone(),
         cancel,
     ));
 
     join_service(transaction_generator_task_handle, "TransactionGenerator").await?;
+
+    if drain_seconds > 0 {
+        info!("Generator finished; entering drain phase (max {drain_seconds}s).");
+        drain_in_flight(
+            successfully_sent_total.clone(),
+            METRICS_REPORTING_INTERVAL,
+            Duration::from_secs(drain_seconds),
+            DRAIN_TAIL_AFTER_STABLE,
+        )
+        .await;
+    }
+    // Releasing these now closes the scheduler-side receivers and lets the
+    // tpu-client-next instances shut down cleanly.
+    drop(drain_senders);
+
     join_service(blockhash_task_handle, "BlockhashUpdater").await?;
     for (i, handle) in scheduler_handles.into_iter().enumerate() {
         let name = format!("Scheduler-{i}");
         join_service(handle, &name).await?;
     }
+
+    info!(
+        "tx-bench final: successfully_sent={} congestion_events={} write_error={}",
+        successfully_sent_total.load(Ordering::Relaxed),
+        congestion_events_total.load(Ordering::Relaxed),
+        write_error_total.load(Ordering::Relaxed),
+    );
     Ok(())
 }
 

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -190,6 +190,7 @@ pub async fn run_client(
         duration,
         num_transactions,
         target_tps,
+        initial_congestion_window,
         num_max_open_connections,
         workers_pull_size,
         send_fanout,
@@ -340,7 +341,7 @@ pub async fn run_client(
                 connect: send_fanout.saturating_add(1),
             },
             skip_check_transaction_age: false,
-            override_initial_congestion_window: None,
+            override_initial_congestion_window: initial_congestion_window.map(NonZeroU64::get),
         };
 
         let (_, update_identity_receiver) = watch::channel(None);

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -137,6 +137,7 @@ fn test_transactions_sending() {
                 num_transactions: None,
                 target_tps: None,
                 initial_congestion_window: None,
+                drain_seconds: 0,
                 num_max_open_connections: 1,
                 clients_per_identity: 1,
                 workers_pull_size: 1,

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -138,6 +138,7 @@ fn test_transactions_sending() {
                 target_tps: None,
                 initial_congestion_window: None,
                 num_max_open_connections: 1,
+                clients_per_identity: 1,
                 workers_pull_size: 1,
                 send_fanout: 1,
                 compute_unit_price: Some(100),

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -134,6 +134,7 @@ fn test_transactions_sending() {
                 staked_identity_files: vec![],
                 bind: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 0),
                 duration: Some(Duration::from_secs(5)),
+                num_transactions: None,
                 target_tps: None,
                 num_max_open_connections: 1,
                 workers_pull_size: 1,

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -136,6 +136,7 @@ fn test_transactions_sending() {
                 duration: Some(Duration::from_secs(5)),
                 num_transactions: None,
                 target_tps: None,
+                initial_congestion_window: None,
                 num_max_open_connections: 1,
                 workers_pull_size: 1,
                 send_fanout: 1,


### PR DESCRIPTION
Adds four independent enhancements to transaction-bench, aimed at driving and measuring high connection-count load tests against a single (typically pinned) leader. Each is a separate commit and works on its own.

`--num-transactions`

  Optional cap on the total number of transactions scheduled, after which the generator stops. Can be combined with --duration — whichever limit is hit first ends the run. The generator tracks a running count and clamps the final batch so it
  never overshoots the budget.

`--initial-congestion-window`

  Overrides the QUIC initial congestion window (in bytes) passed to tpu-client-next as override_initial_congestion_window. A larger window skips TCP-style slow-start at connection startup so transactions go out at full rate immediately. Defaults
  to tpu-client-next's built-in value (128 * PACKET_DATA_SIZE) when unset.

`--clients-per-identity`

Each tpu-client-next instance opens exactly one QUIC connection per leader (WorkersCache is keyed by leader SocketAddr, one worker = one connection). So the number of connections to a pinned leader equals the number of instances, and previously the only way to get N connections under one identity was to repeat --staked-identity-file N times — impractical for large N.

  This flag (default 1) sets a per-identity multiplier:

  total instances = max(1, num staked identities) * clients-per-identity

  Identities are round-robined across instances (get(i % num_identities)), yielding None/unstaked when no identity file is given. Example — 1000 connections under one identity:

  solana-transaction-bench -u $CLUSTER read-accounts-run \
    --staked-identity-file $STAKED_ID --clients-per-identity 1000 \
    ... pinned-leader-tracker $TARGET

`--drain-seconds`

Post-generation drain phase + detailed stats (--drain-seconds)

After the generator finishes, transactions can still be queued in tpu-client-next's worker channels and quinn send buffers. Tearing the schedulers down immediately drops them — most visible when --num-transactions is set. The drain phase
  (default 10s, 0 to disable) waits until the aggregated successfully_sent count is stable across reporter ticks, then a short fixed tail to let quinn flush, all capped by the timeout.

To support this, report_aggregated_stats now also accumulates non-resetting totals (successfully_sent / congestion_events / write_error) that the drain phase observes, logs per-tick and final totals, and breaks down connection_error /
  write_error by cause.
