### PR TITLE
Fix rate latency tool version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8682,7 +8682,7 @@ dependencies = [
 
 [[package]]
 name = "solana-rate-latency-tool"
-version = "1.0.0"
+version = "0.1.0"
 dependencies = [
  "agave-logger",
  "async-std",

--- a/rate-latency-tool/Cargo.toml
+++ b/rate-latency-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "solana-rate-latency-tool"
-version = "1.0.0"
+version = "0.1.0"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
setting rate latency tool version to v1.0.0 was a typo. Change it to v0.1.0. It has not been released as a public crate. So no issue with rolling the version number back.