### PR TITLE
Update compiler version. Pin components and edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,14 +106,3 @@ lto = "thin"
 inherits = "release"
 lto = "fat"
 codegen-units = 1
-
-# curve25519-dalek uses the simd backend by default in v4 if possible,
-# which has very slow performance on some platforms with opt-level 0,
-# which is the default for dev and test builds.
-# This slowdown causes certain interactions in the solana-test-validator,
-# such as verifying ZK proofs in transactions, to take much more than 400ms,
-# creating problems in the testing environment.
-# To enable better performance in solana-test-validator during tests and dev builds,
-# we override the opt-level to 3 for the crate.
-[profile.dev.package.curve25519-dalek]
-opt-level = 3

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,5 @@
 [toolchain]
-channel = "1.93.0"
+channel = "1.93.1"
+components = ["clippy", "rustfmt"]
+targets = []
+profile = "minimal"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
 imports_granularity = "One"
 format_strings = true
 group_imports = "One"
+edition = "2024"
 style_edition = "2024"


### PR DESCRIPTION
* Both Agave v4.0 branch and Yellowstone v13.1 branch use Rust 1.93.1. Match them.
* Drop profile config for dalek package we don't use inherited from agave.
* Pin components and versions in toolchain and rustfmt config files.

