### PR TITLE
Update dependabot cadence and cooldown period

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,14 +9,18 @@ updates:
     directories:
       - "/"
     schedule:
-      interval: weekly
+      interval: monthly
       time: "01:00"
       timezone: America/Los_Angeles
-    open-pull-requests-limit: 6
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: weekly
       time: "01:00"
       timezone: America/Los_Angeles
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
We don't update our crates that frequently and we generally need them to stay in lockstep with Agave. Monthly cadence is plenty. I also added a 7 days cooldown period to match the security settings in other Anza repos.