### PR TITLE
feat: adds delete-account subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -986,7 +986,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -2994,7 +2994,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-link",
 ]
 
@@ -4078,9 +4078,9 @@ checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libloading"
@@ -4226,9 +4226,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -4479,9 +4479,9 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.31.1"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225e7cfe711e0ba79a68baeddb2982723e4235247aefce1482f2f16c27865b66"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if 1.0.4",
@@ -4972,7 +4972,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -5913,14 +5913,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -10974,14 +10974,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.24.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -12503,7 +12503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.3",
+ "rustix 1.1.4",
 ]
 
 [[package]]

--- a/rate-latency-tool/src/error.rs
+++ b/rate-latency-tool/src/error.rs
@@ -41,6 +41,9 @@ pub enum RateLatencyToolError {
     #[error("Tool finished unexpectedly")]
     UnexpectedError,
 
+    #[error("Invalid CLI arguments: {0}")]
+    InvalidCliArguments(String),
+
     #[error(transparent)]
     LeaderUpdaterError(#[from] LeaderUpdaterError),
 }

--- a/tpu-tools-common/Cargo.toml
+++ b/tpu-tools-common/Cargo.toml
@@ -3,12 +3,12 @@ name = "solana-tpu-tools-common"
 version = "0.1.0"
 authors = { workspace = true }
 edition = { workspace = true }
+description = "Shared Solana TPU tooling for account setup, blockhash updates, and leader tracking."
+documentation = "https://docs.rs/solana-tpu-tools-common"
+readme = "README.md"
 homepage = { workspace = true }
 repository = { workspace = true }
-documentation = "https://docs.rs/solana-tpu-tools-common"
 license = { workspace = true }
-description = "Shared Solana TPU tooling for account setup, blockhash updates, and leader tracking."
-readme = "README.md"
 keywords = ["solana", "tpu", "benchmark"]
 categories = ["command-line-utilities", "development-tools"]
 
@@ -40,11 +40,7 @@ solana-sdk-ids = { workspace = true }
 solana-signer = { workspace = true }
 solana-system-interface = { workspace = true }
 solana-tpu-client = { workspace = true }
-solana-tpu-client-next = { workspace = true, features = [
-  "agave-unstable-api",
-  "metrics",
-  "websocket-node-address-service"
-] }
+solana-tpu-client-next = { workspace = true, features = ["agave-unstable-api", "metrics", "websocket-node-address-service"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }

--- a/tpu-tools-common/src/accounts_deleter.rs
+++ b/tpu-tools-common/src/accounts_deleter.rs
@@ -1,0 +1,299 @@
+//! RPC-backed payer account draining for TPU tools.
+//!
+//! This module reads payer keypairs from an account file, fetches their current
+//! balances, and transfers those lamports to a recipient account.
+#![allow(clippy::arithmetic_side_effects)]
+use {
+    crate::{accounts_file::read_accounts_file, blockhash_updater::BlockhashUpdater},
+    futures::future::join_all,
+    log::*,
+    solana_hash::Hash,
+    solana_instruction::Instruction,
+    solana_keypair::Keypair,
+    solana_pubkey::Pubkey,
+    solana_rpc_client::nonblocking::rpc_client::RpcClient,
+    solana_rpc_client_api::{
+        client_error::Error as ClientError,
+        response::transaction::{Transaction, versioned::VersionedTransaction},
+    },
+    solana_signer::Signer,
+    solana_system_interface::instruction as system_instruction,
+    std::{collections::HashSet, path::PathBuf, sync::Arc},
+    thiserror::Error,
+    tokio::{
+        sync::watch,
+        time::{Duration, sleep},
+    },
+};
+
+/// Max transfer instructions packed into one transaction (packet size limit).
+const MAX_DELETE_ACC_IX_PER_TX: usize = 9;
+/// Used to sleep between account draining attempts to avoid getting 429s from RPC.
+const ACCOUNT_DELETION_SLEEP_INTERVAL: Duration = Duration::from_millis(150);
+/// Max number of unsuccessful delete accounts attempts.
+const MAX_CONTINUOUS_FAILED_ATTEMPTS: usize = 100;
+
+#[derive(Error, Debug)]
+pub enum Error {
+    /// RPC client request failed.
+    #[error(transparent)]
+    ClientError(#[from] ClientError),
+
+    /// Account draining did not drain every funded account.
+    #[error("Failed to delete account")]
+    DeleteAccountFailure,
+}
+
+/// Reads payer accounts from a file and drains their lamports to `recipient`.
+///
+/// The `authority` keypair pays transaction fees, allowing each payer account
+/// to transfer its full current balance.
+pub async fn delete_file_persisted_accounts(
+    rpc_client: Arc<RpcClient>,
+    authority: Keypair,
+    accounts_file: PathBuf,
+    recipient: Pubkey,
+    txn_batch_size: usize,
+) -> Result<(), Error> {
+    let accounts = read_accounts_file(accounts_file);
+    let account_balances = fetch_account_balances(&rpc_client, accounts.payers).await?;
+    let num_accounts_with_balance = account_balances.len();
+
+    if num_accounts_with_balance == 0 {
+        info!("No funded payer accounts to delete.");
+        return Ok(());
+    }
+
+    let deleted_accounts = delete_accounts(
+        &rpc_client,
+        &authority,
+        &recipient,
+        account_balances,
+        txn_batch_size,
+        MAX_CONTINUOUS_FAILED_ATTEMPTS,
+    )
+    .await;
+
+    if deleted_accounts != num_accounts_with_balance {
+        error!(
+            "Failed to delete all funded payers: {deleted_accounts}/{num_accounts_with_balance} \
+             deleted"
+        );
+        return Err(Error::DeleteAccountFailure);
+    }
+
+    info!("Payers have been deleted.");
+    Ok(())
+}
+
+async fn fetch_account_balances(
+    rpc_client: &Arc<RpcClient>,
+    payers: Vec<Keypair>,
+) -> Result<Vec<(Keypair, u64)>, Error> {
+    let balance_futures = payers.iter().map(|payer| {
+        let pubkey = payer.pubkey();
+        async move { rpc_client.get_balance(&pubkey).await }
+    });
+    let balances = join_all(balance_futures)
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(payers
+        .into_iter()
+        .zip(balances)
+        .filter(|(_, balance)| *balance > 0)
+        .collect())
+}
+
+fn create_delete_transaction_batch(
+    authority: &Keypair,
+    recipient: &Pubkey,
+    blockhash: Hash,
+    account_balances: &[(Keypair, u64)],
+) -> Vec<(VersionedTransaction, Vec<Pubkey>)> {
+    let mut remaining_accounts = account_balances;
+    let mut transactions = Vec::new();
+
+    while !remaining_accounts.is_empty() {
+        let chunk_size = remaining_accounts.len().min(MAX_DELETE_ACC_IX_PER_TX);
+        let (chunk, remaining) = remaining_accounts.split_at(chunk_size);
+        remaining_accounts = remaining;
+
+        let instructions: Vec<Instruction> = chunk
+            .iter()
+            .map(|(payer, balance)| {
+                system_instruction::transfer(&payer.pubkey(), recipient, *balance)
+            })
+            .collect();
+        let signers: Vec<&Keypair> = std::iter::once(authority)
+            .chain(chunk.iter().map(|(payer, _)| payer))
+            .collect();
+        let drained_accounts = chunk.iter().map(|(payer, _)| payer.pubkey()).collect();
+        let transaction = Transaction::new_signed_with_payer(
+            &instructions,
+            Some(&authority.pubkey()),
+            &signers,
+            blockhash,
+        )
+        .into();
+
+        transactions.push((transaction, drained_accounts));
+    }
+
+    transactions
+}
+
+async fn send_transaction_batch(
+    rpc_client: &Arc<RpcClient>,
+    transaction_batch: Vec<(VersionedTransaction, Vec<Pubkey>)>,
+) -> Vec<Pubkey> {
+    let futures = transaction_batch
+        .into_iter()
+        .map(|(tx, account_pubkeys)| async move {
+            (
+                rpc_client.send_and_confirm_transaction(&tx).await,
+                account_pubkeys,
+            )
+        });
+    let results = join_all(futures).await;
+    results
+        .into_iter()
+        .filter_map(|(result, account_pubkeys)| result.ok().map(|_| account_pubkeys))
+        .flatten()
+        .collect()
+}
+
+fn calculate_batch_size(
+    num_accounts: usize,
+    num_deleted_accounts: usize,
+    num_send_batch_attempts: usize,
+    txn_batch_size: usize,
+) -> usize {
+    let mean_num_success = num_deleted_accounts
+        .checked_div(num_send_batch_attempts)
+        .unwrap_or(std::cmp::min(num_accounts, txn_batch_size));
+    std::cmp::min(mean_num_success + 1, num_accounts - num_deleted_accounts)
+}
+
+async fn delete_accounts(
+    rpc_client: &Arc<RpcClient>,
+    authority: &Keypair,
+    recipient: &Pubkey,
+    account_balances: Vec<(Keypair, u64)>,
+    txn_batch_size: usize,
+    max_continuous_failed_attempts: usize,
+) -> usize {
+    let num_accounts = account_balances.len();
+    let mut pending_accounts = account_balances;
+    let mut num_send_batch_attempts = 0;
+    let mut num_continuous_failed_attempts = 0;
+
+    let blockhash = loop {
+        if num_continuous_failed_attempts >= max_continuous_failed_attempts {
+            return 0;
+        }
+
+        if let Ok(bh) = rpc_client.get_latest_blockhash().await {
+            break bh;
+        }
+        num_continuous_failed_attempts += 1;
+        sleep(ACCOUNT_DELETION_SLEEP_INTERVAL).await;
+    };
+
+    let (blockhash_sender, blockhash_receiver) = watch::channel(blockhash);
+    let blockhash_updater = BlockhashUpdater::new(rpc_client.clone(), blockhash_sender);
+
+    tokio::spawn(async move { blockhash_updater.run().await });
+
+    while !pending_accounts.is_empty() {
+        let num_deleted_accounts = num_accounts - pending_accounts.len();
+        if num_continuous_failed_attempts >= max_continuous_failed_attempts {
+            error!(
+                "Failed to delete accounts. num_send_batch_attempts: {num_send_batch_attempts}, \
+                 num_deleted_accounts: {num_deleted_accounts}."
+            );
+            break;
+        }
+
+        let blockhash = *blockhash_receiver.borrow();
+        let current_batch_size = calculate_batch_size(
+            num_accounts,
+            num_deleted_accounts,
+            num_send_batch_attempts,
+            txn_batch_size,
+        );
+        debug!(
+            "current_batch_size: {current_batch_size}, num_deleted_accounts: \
+             {num_deleted_accounts}, num_continuous_failed_attempts: \
+             {num_continuous_failed_attempts}."
+        );
+
+        let transaction_batch = create_delete_transaction_batch(
+            authority,
+            recipient,
+            blockhash,
+            &pending_accounts[..current_batch_size],
+        );
+        let deleted_accounts = send_transaction_batch(rpc_client, transaction_batch).await;
+        num_continuous_failed_attempts = if deleted_accounts.is_empty() {
+            num_continuous_failed_attempts + 1
+        } else {
+            0
+        };
+
+        let deleted_accounts: HashSet<_> = deleted_accounts.into_iter().collect();
+        pending_accounts.retain(|(payer, _)| !deleted_accounts.contains(&payer.pubkey()));
+
+        num_send_batch_attempts += 1;
+        sleep(ACCOUNT_DELETION_SLEEP_INTERVAL).await;
+    }
+
+    num_accounts - pending_accounts.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, solana_keypair::Keypair, solana_rpc_client::nonblocking::rpc_client::RpcClient,
+    };
+
+    #[tokio::test]
+    async fn test_delete_transaction_size_within_txn_limit() {
+        let rpc = RpcClient::new_mock("succeeds".to_string());
+        let blockhash = rpc.get_latest_blockhash().await.unwrap();
+        let authority = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let account_balances: Vec<_> = (0..MAX_DELETE_ACC_IX_PER_TX)
+            .map(|_| (Keypair::new(), 1_000))
+            .collect();
+
+        let txs =
+            create_delete_transaction_batch(&authority, &recipient, blockhash, &account_balances);
+
+        assert_eq!(txs.len(), 1);
+
+        const SOLANA_TXN_MAX_BYTES: usize = 1232;
+        let txn_size = bincode::serialized_size(&txs[0].0)
+            .expect("transaction should be bincode-serializable") as usize;
+        assert!(
+            txn_size <= SOLANA_TXN_MAX_BYTES,
+            "serialized transaction size {txn_size} exceeds Solana limit {SOLANA_TXN_MAX_BYTES}"
+        );
+    }
+
+    #[test]
+    fn test_zero_balance_accounts_are_skipped() {
+        let funded = Keypair::new();
+        let zero_balance = Keypair::new();
+        let account_balances = vec![(funded.insecure_clone(), 100), (zero_balance, 0)];
+
+        let filtered: Vec<_> = account_balances
+            .into_iter()
+            .filter(|(_, balance)| *balance > 0)
+            .collect();
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(filtered[0].0.pubkey(), funded.pubkey());
+    }
+}

--- a/tpu-tools-common/src/cli.rs
+++ b/tpu-tools-common/src/cli.rs
@@ -8,10 +8,15 @@ use {
     solana_clap_v3_utils::{
         input_parsers::parse_url_or_moniker, input_validators::normalize_to_url_if_moniker,
     },
+    solana_keypair::Keypair,
     solana_native_token::LAMPORTS_PER_SOL,
-    std::{net::SocketAddr, path::PathBuf},
+    solana_pubkey::Pubkey,
+    solana_signer::{EncodableKey, Signer},
+    std::{net::SocketAddr, path::PathBuf, str::FromStr},
     tokio::time::Duration,
 };
+
+const MAX_RPC_SEND_TX_BATCH: usize = 60;
 
 #[derive(Subcommand, Debug, Clone, PartialEq, Eq)]
 #[clap(rename_all = "kebab-case")]
@@ -88,6 +93,42 @@ pub struct ReadAccounts {
     pub accounts_file: PathBuf,
 }
 
+/// Parameters for draining payer accounts from a file.
+#[derive(Args, Debug, PartialEq, Eq, Clone)]
+#[clap(rename_all = "kebab-case")]
+pub struct DeleteAccounts {
+    #[clap(long, help = "File to read the accounts from.")]
+    pub accounts_file: PathBuf,
+
+    #[clap(
+        long,
+        help = "Account that receives all drained lamports. Accepts a base58 pubkey or a keypair \
+                file path."
+    )]
+    pub recipient: String,
+
+    #[clap(long, default_value_t = MAX_RPC_SEND_TX_BATCH, help = "Maximum number of transactions to send concurrently in a batch.")]
+    pub txn_batch_size: usize,
+}
+
+/// Parses a recipient as a base58 pubkey, or reads a pubkey from a keypair file path.
+pub fn parse_recipient(recipient: &str) -> Result<Pubkey, String> {
+    let recipient = recipient.trim();
+
+    if let Ok(pubkey) = Pubkey::from_str(recipient) {
+        return Ok(pubkey);
+    }
+
+    let path = PathBuf::from(recipient);
+    if let Ok(keypair) = Keypair::read_from_file(&path) {
+        return Ok(keypair.pubkey());
+    }
+
+    Err(format!(
+        "invalid recipient '{recipient}': expected a base58 pubkey or a keypair file path"
+    ))
+}
+
 /// Parses an RPC URL or Solana moniker and normalizes monikers to URLs.
 pub fn parse_and_normalize_url(addr: &str) -> Result<String, String> {
     match parse_url_or_moniker(addr) {
@@ -129,6 +170,17 @@ fn parse_balance(s: &str) -> Result<u64, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_recipient_from_pubkey() {
+        let pubkey = Pubkey::new_unique();
+        assert_eq!(parse_recipient(&pubkey.to_string()).unwrap(), pubkey);
+    }
+
+    #[test]
+    fn test_parse_recipient_rejects_invalid_value() {
+        assert!(parse_recipient("not-a-pubkey-or-keypair").is_err());
+    }
 
     #[test]
     fn test_parse_balance() {

--- a/tpu-tools-common/src/lib.rs
+++ b/tpu-tools-common/src/lib.rs
@@ -12,6 +12,7 @@
 //! - [`accounts_file`]: read and write payer account files, and create
 //!   ephemeral or file-persisted payer accounts.
 //! - [`accounts_creator`]: RPC-backed payer account creation.
+//! - [`accounts_deleter`]: RPC-backed payer account draining.
 //! - [`cli`]: shared Clap argument structs and parsers.
 //! - [`blockhash_updater`]: background RPC polling for fresh blockhashes.
 //! - [`leader_updater`]: leader tracking traits and factory function.
@@ -24,6 +25,7 @@
 //! release candidate dependencies evolve.
 
 pub mod accounts_creator;
+pub mod accounts_deleter;
 pub mod accounts_file;
 pub mod blockhash_updater;
 pub mod cli;

--- a/transaction-bench/README.md
+++ b/transaction-bench/README.md
@@ -78,6 +78,21 @@ run_args=(
 solana-transaction-bench "${run_args[@]}"
 ```
 
+To drain a saved accounts file after testing, use `delete-accounts`. The payer accounts are loaded
+from the same JSON format produced by `write-accounts`; `--authority` pays transaction fees, and
+`--recipient` receives the payer balances.
+
+```shell
+delete_accounts_args=(
+  -u "$URL"
+  --authority "$FUNDER_KEYPAIR"
+  delete-accounts
+  --accounts-file accounts.json
+  --recipient "$RECIPIENT_PUBKEY"
+)
+solana-transaction-bench "${delete_accounts_args[@]}"
+```
+
 #### Multiple Staked Identities
 
 Pass `--staked-identity-file` more than once to spawn multiple

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -6,7 +6,9 @@ use {
     },
     solana_commitment_config::CommitmentConfig,
     solana_pubkey::Pubkey,
-    solana_tpu_tools_common::cli::{AccountParams, LeaderTracker, ReadAccounts, WriteAccounts},
+    solana_tpu_tools_common::cli::{
+        AccountParams, DeleteAccounts, LeaderTracker, ReadAccounts, WriteAccounts,
+    },
     std::{
         net::SocketAddr,
         num::{NonZeroU64, NonZeroUsize},
@@ -102,6 +104,9 @@ pub enum Command {
 
     #[clap(about = "Create accounts and save them to a file, skipping the execution")]
     WriteAccounts(WriteAccounts),
+
+    #[clap(about = "Transfer all lamports from account-file payers to a recipient")]
+    DeleteAccounts(DeleteAccounts),
 }
 
 #[derive(Args, Clone, Debug, PartialEq, Eq)]
@@ -616,6 +621,45 @@ mod tests {
             command: Command::WriteAccounts(WriteAccounts {
                 accounts_file: accounts_file_name.into(),
                 account_params,
+            }),
+            authority: Some(PathBuf::from(&keypair_file_name)),
+            validate_accounts: false,
+            mock_rpc: false,
+        };
+        let cli = ClientCliParameters::try_parse_from(args);
+        assert!(cli.is_ok(), "Unexpected error {:?}", cli.err());
+        let actual = cli.unwrap();
+
+        assert_eq!(actual, expected_parameters);
+    }
+
+    #[test]
+    fn test_delete_accounts_command() {
+        let keypair_file_name = "/home/testUser/masterKey.json";
+        let accounts_file_name = "/home/testUser/accountsFile.json";
+        let recipient = Pubkey::new_unique();
+        let recipient_string = recipient.to_string();
+
+        let args = vec![
+            "test",
+            "-ul",
+            "--authority",
+            keypair_file_name,
+            "delete-accounts",
+            "--accounts-file",
+            accounts_file_name,
+            "--recipient",
+            &recipient_string,
+        ];
+
+        const MAX_RPC_SEND_TX_BATCH: usize = 60;
+        let expected_parameters = ClientCliParameters {
+            json_rpc_url: "http://localhost:8899".to_string(),
+            commitment_config: CommitmentConfig::confirmed(),
+            command: Command::DeleteAccounts(DeleteAccounts {
+                accounts_file: accounts_file_name.into(),
+                recipient: recipient_string.clone(),
+                txn_batch_size: MAX_RPC_SEND_TX_BATCH,
             }),
             authority: Some(PathBuf::from(&keypair_file_name)),
             validate_accounts: false,

--- a/transaction-bench/src/error.rs
+++ b/transaction-bench/src/error.rs
@@ -3,7 +3,8 @@ use {
     crate::generator::transaction_generator::TransactionGeneratorError,
     solana_tpu_client_next::ConnectionWorkersSchedulerError,
     solana_tpu_tools_common::{
-        accounts_creator::Error as AccountsCreatorError, accounts_file::Error as AccountsFileError,
+        accounts_creator::Error as AccountsCreatorError,
+        accounts_deleter::Error as AccountsDeleterError, accounts_file::Error as AccountsFileError,
         blockhash_updater::BlockhashUpdaterError, leader_updater::Error as LeaderUpdaterError,
     },
     thiserror::Error,
@@ -13,6 +14,9 @@ use {
 pub enum BenchClientError {
     #[error(transparent)]
     AccountsCreatorError(#[from] AccountsCreatorError),
+
+    #[error(transparent)]
+    AccountsDeleterError(#[from] AccountsDeleterError),
 
     #[error(transparent)]
     ConnectionTasksSchedulerError(#[from] ConnectionWorkersSchedulerError),

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -7,11 +7,12 @@ use {
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::{EncodableKey, Signer},
     solana_tpu_tools_common::{
+        accounts_deleter::delete_file_persisted_accounts,
         accounts_file::{
             AccountsFile, create_ephemeral_accounts, create_file_persisted_accounts,
             read_accounts_file,
         },
-        cli::LeaderTracker,
+        cli::{LeaderTracker, parse_recipient},
     },
     solana_transaction_bench::{
         cli::{ClientCliParameters, Command, build_cli_parameters},
@@ -50,7 +51,8 @@ fn main() {
 async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
     validate_mock_rpc_usage(&parameters)?;
 
-    let authority = if let Some(authority_file) = parameters.authority {
+    let authority_provided = parameters.authority.is_some();
+    let authority = if let Some(authority_file) = parameters.authority.as_ref() {
         Keypair::read_from_file(authority_file)
             .map_err(|_err| BenchClientError::KeypairReadFailure)?
     } else {
@@ -140,6 +142,23 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
             )
             .await?;
         }
+        Command::DeleteAccounts(delete_accounts) => {
+            if !authority_provided {
+                return Err(BenchClientError::InvalidCliArguments(
+                    "`delete-accounts` requires --authority to pay transaction fees".to_string(),
+                ));
+            }
+            let recipient = parse_recipient(&delete_accounts.recipient)
+                .map_err(BenchClientError::InvalidCliArguments)?;
+            delete_file_persisted_accounts(
+                rpc_client.clone(),
+                authority,
+                delete_accounts.accounts_file,
+                recipient,
+                delete_accounts.txn_batch_size,
+            )
+            .await?;
+        }
     }
 
     Ok(())
@@ -176,9 +195,12 @@ fn validate_mock_rpc_usage(parameters: &ClientCliParameters) -> Result<(), Bench
         ));
     }
 
-    if matches!(&parameters.command, Command::WriteAccounts(_)) {
+    if matches!(
+        &parameters.command,
+        Command::WriteAccounts(_) | Command::DeleteAccounts(_)
+    ) {
         return Err(BenchClientError::InvalidCliArguments(
-            "--mock-rpc does not support `write-accounts`".to_string(),
+            "--mock-rpc does not support account file mutation commands".to_string(),
         ));
     }
 
@@ -284,7 +306,7 @@ mod tests {
     use {
         super::*,
         solana_commitment_config::CommitmentConfig,
-        solana_tpu_tools_common::cli::{AccountParams, WriteAccounts},
+        solana_tpu_tools_common::cli::{AccountParams, DeleteAccounts, WriteAccounts},
         solana_transaction_bench::cli::{
             ExecutionParams, InstructionPaddingParams, PriorityFeeParams, SimpleTransferTxParams,
             TransactionParams,
@@ -367,7 +389,28 @@ mod tests {
         let err = validate_mock_rpc_usage(&parameters)
             .unwrap_err()
             .to_string();
-        assert!(err.contains("write-accounts"));
+        assert!(err.contains("account file mutation"));
+    }
+
+    #[test]
+    fn test_mock_rpc_rejects_delete_accounts() {
+        let parameters = ClientCliParameters {
+            json_rpc_url: "http://localhost:8899".to_string(),
+            commitment_config: CommitmentConfig::confirmed(),
+            authority: None,
+            validate_accounts: false,
+            mock_rpc: true,
+            command: Command::DeleteAccounts(DeleteAccounts {
+                accounts_file: "accounts.json".into(),
+                recipient: solana_pubkey::Pubkey::new_unique().to_string(),
+                txn_batch_size: 64,
+            }),
+        };
+
+        let err = validate_mock_rpc_usage(&parameters)
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("account file mutation"));
     }
 
     #[test]


### PR DESCRIPTION
### Summary
Adds `delete-accounts` subcommand which allows you to specify a json file(created using the `write-accounts` sub-command) to transfer all their funds to a specified `--recipient`

## What changes

- **`tpu-tools-common`**: new `accounts_deleter` module and `DeleteAccounts` CLI args
- **`transaction-bench`** and **`rate-latency-tool`**: wire up `delete-accounts`, require `--authority`, reject `--mock-rpc` for account file commands
- **READMEs**: document the drain workflow after `write-accounts`
- **Tests**: CLI parsing tests in both tools; unit tests for transaction size limits and zero-balance filtering in `accounts_deleter`

## Tests

```shell
cargo test -p solana-tpu-tools-common accounts_deleter
cargo test -p solana-transaction-bench test_delete_accounts
cargo test -p solana-rate-latency-tool test_delete_accounts
```

Closes https://github.com/anza-xyz/tpu-tools/issues/93