### PR TITLE
rename --lamports-to-transfer to --max-lamports-to-transfer, change default, pregenerate rnd numbers 

### DIFF
--- a/transaction-bench/README.md
+++ b/transaction-bench/README.md
@@ -55,9 +55,9 @@ solana-transaction-bench "${create_accounts_args[@]}"
 ```
 
 After `accounts.json` is created, use `read-accounts-run` to start sending transactions. A high
-`--lamports-to-transfer` value gives the generator enough unique transfer amounts to avoid duplicate
-transactions within generated batches. Here we use `ws-leader-tracker` to keep track of leaders
-using websocket.
+`--max-lamports-to-transfer` value gives the generator enough unique transfer amounts from the
+inclusive range `1..=max` to avoid duplicate transactions within generated batches. Here we use
+`ws-leader-tracker` to keep track of leaders using websocket.
 
 ```shell
 run_args=(
@@ -71,7 +71,7 @@ run_args=(
   --workers-pull-size 8
   --send-fanout 1
   --transfer-tx-cu-budget 350
-  --lamports-to-transfer 8096
+  --max-lamports-to-transfer 8096
   --num-send-instructions-per-tx 1
   ws-leader-tracker
 )

--- a/transaction-bench/README.md
+++ b/transaction-bench/README.md
@@ -56,8 +56,8 @@ solana-transaction-bench "${create_accounts_args[@]}"
 
 After `accounts.json` is created, use `read-accounts-run` to start sending transactions. A high
 `--max-lamports-to-transfer` value gives the generator enough unique transfer amounts from the
-inclusive range `1..=max` to avoid duplicate transactions within generated batches. Here we use
-`ws-leader-tracker` to keep track of leaders using websocket.
+inclusive range `1..=max` to avoid duplicate transactions within generated batches. The default is
+`65536`. Here we use `ws-leader-tracker` to keep track of leaders using websocket.
 
 ```shell
 run_args=(
@@ -71,7 +71,7 @@ run_args=(
   --workers-pull-size 8
   --send-fanout 1
   --transfer-tx-cu-budget 350
-  --max-lamports-to-transfer 8096
+  --max-lamports-to-transfer 65536
   --num-send-instructions-per-tx 1
   ws-leader-tracker
 )

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -255,7 +255,7 @@ pub struct SimpleTransferTxParams {
                 in a generated batch, select a unique random value from the range [1, this value]\n\
                 to provide more entropy for transactions. Defaults to 65536.\n"
     )]
-    pub lamports_to_transfer: u64,
+    pub max_lamports_to_transfer: u64,
 
     #[clap(long, default_value = "600", help = "Transfer transaction CU budget.")]
     pub transfer_tx_cu_budget: u32,
@@ -429,7 +429,7 @@ mod tests {
             command: Command::Run {
                 transaction_params: TransactionParams {
                     simple_transfer_tx_params: SimpleTransferTxParams {
-                        lamports_to_transfer: 1000,
+                        max_lamports_to_transfer: 1000,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
                         tx_batch_size: None,
@@ -484,7 +484,7 @@ mod tests {
 
                 transaction_params: TransactionParams {
                     simple_transfer_tx_params: SimpleTransferTxParams {
-                        lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
+                        max_lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                         transfer_tx_cu_budget: 1000,
                         num_send_instructions_per_tx: 2,
                         tx_batch_size: None,
@@ -513,7 +513,7 @@ mod tests {
     fn test_instruction_padding_config_defaults_program_id() {
         let params = TransactionParams {
             simple_transfer_tx_params: SimpleTransferTxParams {
-                lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
+                max_lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx: 1,
                 tx_batch_size: None,

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -249,11 +249,11 @@ pub struct SimpleTransferTxParams {
     #[clap(
         long = "max-lamports-to-transfer",
         alias = "lamports-to-transfer",
-        default_value = "513",
+        default_value_t = DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
         value_parser = value_parser!(u64).range(513..),
         help = "Max lamports to transfer in a transfer instruction. For each transfer instruction \
                 in a generated batch, select a unique random value from the range [1, this value]\n\
-                to provide more entropy for transactions.\n"
+                to provide more entropy for transactions. Defaults to 65536.\n"
     )]
     pub lamports_to_transfer: u64,
 
@@ -284,6 +284,8 @@ pub struct SimpleTransferTxParams {
     )]
     pub num_conflict_groups: Option<NonZeroUsize>,
 }
+
+const DEFAULT_MAX_LAMPORTS_TO_TRANSFER: u64 = 65_536;
 
 fn parse_duration(s: &str) -> Result<Duration, &'static str> {
     s.parse::<u64>()
@@ -482,7 +484,7 @@ mod tests {
 
                 transaction_params: TransactionParams {
                     simple_transfer_tx_params: SimpleTransferTxParams {
-                        lamports_to_transfer: 513,
+                        lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                         transfer_tx_cu_budget: 1000,
                         num_send_instructions_per_tx: 2,
                         tx_batch_size: None,
@@ -511,7 +513,7 @@ mod tests {
     fn test_instruction_padding_config_defaults_program_id() {
         let params = TransactionParams {
             simple_transfer_tx_params: SimpleTransferTxParams {
-                lamports_to_transfer: 513,
+                lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx: 1,
                 tx_batch_size: None,

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -247,10 +247,12 @@ impl TransactionParams {
 #[clap(rename_all = "kebab-case")]
 pub struct SimpleTransferTxParams {
     #[clap(
-        long,
+        long = "max-lamports-to-transfer",
+        alias = "lamports-to-transfer",
         default_value = "513",
         value_parser = value_parser!(u64).range(513..),
-        help = "Max lamports to transfer in a transfer transaction, we select a random value in the range [0, this value]\n\
+        help = "Max lamports to transfer in a transfer instruction. For each transfer instruction \
+                in a generated batch, select a unique random value from the range [1, this value]\n\
                 to provide more entropy for transactions.\n"
     )]
     pub lamports_to_transfer: u64,
@@ -409,7 +411,7 @@ mod tests {
             "--authority",
             keypair_file_name,
             "run",
-            "--lamports-to-transfer",
+            "--max-lamports-to-transfer",
             "1000",
             "--transfer-tx-cu-budget",
             "600",
@@ -542,7 +544,7 @@ mod tests {
             "--authority",
             keypair_file_name,
             "run",
-            "--lamports-to-transfer",
+            "--max-lamports-to-transfer",
             "1000",
             "--transfer-tx-cu-budget",
             "600",

--- a/transaction-bench/src/generator/simple_transfers_generator.rs
+++ b/transaction-bench/src/generator/simple_transfers_generator.rs
@@ -5,11 +5,10 @@ use {
         priority_fee::{PriorityFeeMode, PriorityFeeStats},
     },
     log::debug,
-    rand::{seq::IteratorRandom, thread_rng},
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_measure::measure::Measure,
-    std::{num::NonZeroUsize, sync::Arc},
+    std::{num::NonZeroUsize, ops::Range, sync::Arc},
     tokio::task::JoinHandle,
 };
 
@@ -19,6 +18,7 @@ use {
 pub(crate) fn generate_transfer_transaction_batch(
     payers: Arc<Vec<Keypair>>,
     payer_index: usize,
+    lamports_pool: SharedSlice<u64>,
     blockhash: Hash,
     TransactionParams {
         simple_transfer_tx_params,
@@ -39,20 +39,18 @@ pub(crate) fn generate_transfer_transaction_batch(
         }
         .instruction_padding_config();
 
-        let lamports_to_transfer = simple_transfer_tx_params.lamports_to_transfer;
         let transfer_tx_cu_budget = simple_transfer_tx_params.transfer_tx_cu_budget;
         let num_send_instructions_per_tx = simple_transfer_tx_params.num_send_instructions_per_tx;
         let num_conflict_groups = simple_transfer_tx_params.num_conflict_groups;
 
         let total_pairs = num_send_instructions_per_tx * send_batch_size;
+        let mut lamports = lamports_pool.as_slice().iter();
 
-        let lamports_to_transfer = unique_random_numbers(total_pairs, lamports_to_transfer);
         let (accounts_from, accounts_to) =
             build_accounts_from_to_lists(&payers, payer_index, total_pairs, num_conflict_groups);
 
         let mut accounts_from_iter = accounts_from.iter().copied();
         let mut accounts_to_iter = accounts_to.iter().copied();
-        let mut lamports = lamports_to_transfer.iter();
         let mut instructions = Vec::with_capacity(num_send_instructions_per_tx);
         let mut signers: Vec<&Keypair> = Vec::with_capacity(num_send_instructions_per_tx);
 
@@ -122,18 +120,6 @@ fn build_accounts_from_to_lists<'a>(
     (accounts_from, accounts_to)
 }
 
-fn unique_random_numbers(count: usize, lamports_to_transfer: u64) -> Vec<u64> {
-    assert!(
-        count as u64 <= lamports_to_transfer,
-        "Not enough unique values in range: {count} > {lamports_to_transfer}"
-    );
-
-    let mut rng = thread_rng();
-
-    // Sample `count` unique values from the full range
-    (1..=lamports_to_transfer).choose_multiple(&mut rng, count)
-}
-
 /// Helper to spawn a blocking task for generating a batch of transactions.
 /// Manages performance measurement and logging.
 fn spawn_blocking_transaction_batch_generation<F>(
@@ -155,6 +141,25 @@ where
         );
         txs
     })
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedSlice<T> {
+    data: Arc<[T]>,
+    range: Range<usize>,
+}
+
+impl<T> SharedSlice<T> {
+    pub fn new(data: Arc<[T]>, range: Range<usize>) -> Self {
+        assert!(range.start <= range.end);
+        assert!(range.end <= data.len());
+
+        Self { data, range }
+    }
+
+    pub fn as_slice(&self) -> &[T] {
+        &self.data[self.range.clone()]
+    }
 }
 
 #[cfg(test)]

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -2,10 +2,11 @@
 use {
     crate::{
         cli::{SimpleTransferTxParams, TransactionParams},
-        generator::simple_transfers_generator::generate_transfer_transaction_batch,
+        generator::simple_transfers_generator::{SharedSlice, generate_transfer_transaction_batch},
         priority_fee::{PriorityFeeMode, PriorityFeeStats},
     },
     log::*,
+    rand::{seq::SliceRandom, thread_rng},
     solana_hash::Hash,
     solana_measure::measure::Measure,
     solana_tpu_client_next::transaction_batch::TransactionBatch,
@@ -103,6 +104,13 @@ impl TransactionGenerator {
             return Err(TransactionGeneratorError::GenerateTxBatchFailure);
         }
 
+        let lamports_pool_size = self
+            .transaction_params
+            .simple_transfer_tx_params
+            .max_lamports_to_transfer as usize;
+        let mut lamports_pool = create_lamports_pool(lamports_pool_size);
+        let mut lamports_index: usize = 0;
+
         let num_senders = self.transactions_senders.len();
         let mut sender_index: usize = 0;
         let start = Instant::now();
@@ -142,13 +150,20 @@ impl TransactionGenerator {
                         let num_send_instructions_per_tx = transaction_params
                             .simple_transfer_tx_params
                             .num_send_instructions_per_tx;
+                        let total_pairs = num_send_instructions_per_tx * send_batch_size;
                         let num_conflict_groups = transaction_params
                             .simple_transfer_tx_params
                             .num_conflict_groups;
+                        let lamports = next_lamports_slice(
+                            &mut lamports_pool,
+                            &mut lamports_index,
+                            total_pairs,
+                        );
                         futures.spawn(async move {
                             let Ok(wired_tx_batch) = generate_transfer_transaction_batch(
                                 payers,
                                 index_payer,
+                                lamports,
                                 blockhash,
                                 transaction_params,
                                 compute_unit_price,
@@ -164,7 +179,6 @@ impl TransactionGenerator {
 
                             send_batch(wired_tx_batch, transactions_sender).await;
                         });
-                        let total_pairs = num_send_instructions_per_tx * send_batch_size;
 
                         let receivers_consumed =
                             num_conflict_groups.map(|g| g.get()).unwrap_or(total_pairs);
@@ -252,12 +266,40 @@ fn compute_batch_interval(send_batch_size: usize, target_tps: NonZeroU64) -> Dur
     Duration::from_nanos(u64::try_from(batch_interval_nanos).unwrap_or(u64::MAX))
 }
 
+fn create_lamports_pool(max_lamports_to_transfer: usize) -> Arc<[u64]> {
+    let mut lamports: Vec<u64> = (1..=max_lamports_to_transfer as u64).collect();
+    let mut rng = thread_rng();
+
+    lamports.shuffle(&mut rng);
+    lamports.into()
+}
+
+fn next_lamports_slice(
+    lamports_pool: &mut Arc<[u64]>,
+    lamports_index: &mut usize,
+    total_pairs: usize,
+) -> SharedSlice<u64> {
+    assert!(total_pairs <= lamports_pool.len());
+
+    if lamports_pool.len().saturating_sub(*lamports_index) < total_pairs {
+        *lamports_pool = create_lamports_pool(lamports_pool.len());
+        *lamports_index = 0;
+    }
+
+    let lamports_end = lamports_index
+        .checked_add(total_pairs)
+        .expect("lamports slice end must fit usize");
+    let lamports = SharedSlice::new(lamports_pool.clone(), *lamports_index..lamports_end);
+    *lamports_index = lamports_end;
+    lamports
+}
+
 #[cfg(test)]
 mod tests {
     use {
-        super::{compute_batch_interval, compute_transfer_tx_min_cu_budget},
+        super::{compute_batch_interval, compute_transfer_tx_min_cu_budget, next_lamports_slice},
         crate::cli::{InstructionPaddingParams, SimpleTransferTxParams, TransactionParams},
-        std::num::NonZeroU64,
+        std::{num::NonZeroU64, sync::Arc},
         tokio::time::Duration,
     };
 
@@ -303,6 +345,32 @@ mod tests {
         assert_eq!(actual, 2 * 3_000);
     }
 
+    #[test]
+    fn test_next_lamports_slice_advances_without_reshuffle() {
+        let mut pool: Arc<[u64]> = Arc::from([1, 2, 3, 4]);
+        let mut index = 0;
+
+        let first = next_lamports_slice(&mut pool, &mut index, 2);
+        let second = next_lamports_slice(&mut pool, &mut index, 2);
+
+        assert_eq!(first.as_slice(), &[1, 2]);
+        assert_eq!(second.as_slice(), &[3, 4]);
+        assert_eq!(index, 4);
+    }
+
+    #[test]
+    fn test_next_lamports_slice_reshuffles_when_tail_is_too_short() {
+        let mut pool: Arc<[u64]> = Arc::from([1, 2, 3, 4]);
+        let mut index = 0;
+
+        let old_slice = next_lamports_slice(&mut pool, &mut index, 3);
+        let new_slice = next_lamports_slice(&mut pool, &mut index, 3);
+
+        assert_eq!(old_slice.as_slice(), &[1, 2, 3]);
+        assert_eq!(new_slice.as_slice().len(), 3);
+        assert_eq!(index, 3);
+    }
+
     fn make_transaction_params(
         num_send_instructions_per_tx: usize,
         instruction_padding_data_size: Option<u32>,
@@ -310,7 +378,7 @@ mod tests {
     ) -> TransactionParams {
         TransactionParams {
             simple_transfer_tx_params: SimpleTransferTxParams {
-                lamports_to_transfer: 513,
+                max_lamports_to_transfer: 513,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx,
                 tx_batch_size: None,

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -343,7 +343,7 @@ mod tests {
                 },
                 transaction_params: TransactionParams {
                     simple_transfer_tx_params: SimpleTransferTxParams {
-                        lamports_to_transfer: 513,
+                        max_lamports_to_transfer: 513,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
                         tx_batch_size: None,

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -179,6 +179,31 @@ pub async fn run_client(
         info!("Using {workers_pull_size} generator workers for target {target_tps} tx/s.");
     }
 
+    {
+        let transfer_instructions_per_batch = transaction_params
+            .simple_transfer_tx_params
+            .num_send_instructions_per_tx
+            .saturating_mul(send_batch_size);
+        if transfer_instructions_per_batch
+            > transaction_params
+                .simple_transfer_tx_params
+                .max_lamports_to_transfer as usize
+        {
+            return Err(BenchClientError::InvalidCliArguments(format!(
+                "--max-lamports-to-transfer ({}) must be >= transfer instructions per generated \
+                 batch ({}) ; computed as num-send-instructions-per-tx ({}) * tx-batch-size ({})",
+                transaction_params
+                    .simple_transfer_tx_params
+                    .max_lamports_to_transfer,
+                transfer_instructions_per_batch,
+                transaction_params
+                    .simple_transfer_tx_params
+                    .num_send_instructions_per_tx,
+                send_batch_size
+            )));
+        }
+    }
+
     if let Some(num_conflict_groups) = transaction_params
         .simple_transfer_tx_params
         .num_conflict_groups

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -125,7 +125,7 @@ fn test_transactions_sending() {
             accounts,
             TransactionParams {
                 simple_transfer_tx_params: SimpleTransferTxParams {
-                    lamports_to_transfer: 513,
+                    max_lamports_to_transfer: 513,
                     transfer_tx_cu_budget: 600,
                     num_send_instructions_per_tx: 1,
                     tx_batch_size: None,


### PR DESCRIPTION
Currently, we use misleading name ` --lamports-to-transfer` which actually means `--max-lamports-to-transfer`.
Since the entropy is taken from the transfer amount (in the absence of random fees), it is better to increase the default amount to some large value.
If we increase the max lamports default, the current method of generating 65k numbers and picking randomly ~512 is suboptimal. So in this PR I pregenarate them, which leads to unique random numbers in range.