### PR TITLE
rate-latency-tool: add connection stats output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8754,6 +8754,7 @@ dependencies = [
  "solana-tpu-client-next",
  "solana-tpu-tools-common",
  "solana-transaction 4.0.0",
+ "solana-transaction-status",
  "spl-memo-interface",
  "thiserror 2.0.18",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8358,6 +8358,7 @@ dependencies = [
  "solana-tpu-client-next",
  "solana-tpu-tools-common",
  "solana-transaction",
+ "solana-transaction-status",
  "spl-memo-interface",
  "thiserror 2.0.19",
  "tokio",

--- a/rate-latency-tool/Cargo.toml
+++ b/rate-latency-tool/Cargo.toml
@@ -70,6 +70,7 @@ solana-rpc = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 solana-test-validator = { workspace = true }
+solana-transaction-status = { workspace = true }
 
 [lints]
 workspace = true

--- a/rate-latency-tool/Cargo.toml
+++ b/rate-latency-tool/Cargo.toml
@@ -72,6 +72,7 @@ solana-rpc = { workspace = true }
 solana-sdk-ids = { workspace = true }
 solana-streamer = { workspace = true, features = ["dev-context-only-utils"] }
 solana-test-validator = { workspace = true }
+solana-transaction-status = { workspace = true }
 
 [lints]
 workspace = true

--- a/rate-latency-tool/src/cli.rs
+++ b/rate-latency-tool/src/cli.rs
@@ -145,6 +145,9 @@ pub struct TxAnalysisParams {
     )]
     pub output_csv_file: Option<PathBuf>,
 
+    #[clap(long, help = "File to write connection close statistics.")]
+    pub connection_stats_csv_file: Option<PathBuf>,
+
     #[clap(
         long,
         value_parser = parse_url,
@@ -224,6 +227,7 @@ mod tests {
             ],
             TxAnalysisParams {
                 output_csv_file: Some(PathBuf::from(csv_file.to_string())),
+                connection_stats_csv_file: None,
                 yellowstone_url: Some(yellowstone_url.to_string()),
                 yellowstone_token: None,
                 check_all_txs: false,
@@ -251,6 +255,48 @@ mod tests {
                 account_params,
                 execution_params,
                 analysis_params,
+            },
+            authority: Some(PathBuf::from(&keypair_file_name)),
+            validate_accounts: false,
+        };
+        let actual = ClientCliParameters::try_parse_from(args).unwrap();
+
+        assert_eq!(actual, expected_parameters);
+    }
+
+    #[test]
+    fn test_connection_stats_csv_file() {
+        let keypair_file_name = "/home/testUser/masterKey.json";
+        let connection_stats_csv_file = "/home/testUser/connection-stats.csv";
+
+        let mut args = vec![
+            "test",
+            "-ul",
+            "--authority",
+            keypair_file_name,
+            "run",
+            "--connection-stats-csv-file",
+            connection_stats_csv_file,
+        ];
+        let (exec_args, execution_params) = get_common_execution_params(keypair_file_name);
+        args.extend(exec_args.iter());
+        let (account_args, account_params) = get_common_account_params();
+        args.extend(account_args.iter());
+        args.push("ws-leader-tracker");
+
+        let expected_parameters = ClientCliParameters {
+            json_rpc_url: "http://localhost:8899".to_string(),
+            commitment_config: CommitmentConfig::confirmed(),
+            command: Command::Run {
+                account_params,
+                execution_params,
+                analysis_params: TxAnalysisParams {
+                    output_csv_file: None,
+                    connection_stats_csv_file: Some(PathBuf::from(connection_stats_csv_file)),
+                    yellowstone_url: None,
+                    yellowstone_token: None,
+                    check_all_txs: false,
+                },
             },
             authority: Some(PathBuf::from(&keypair_file_name)),
             validate_accounts: false,

--- a/rate-latency-tool/src/connection_stats_writer.rs
+++ b/rate-latency-tool/src/connection_stats_writer.rs
@@ -1,0 +1,128 @@
+use {
+    async_std::fs::File,
+    csv_async::{AsyncWriterBuilder, QuoteStyle},
+    log::{debug, error},
+    solana_time_utils::timestamp,
+    solana_tpu_client_next::send_transaction_stats::SendTransactionStatsNonAtomic,
+    std::{net::SocketAddr, path::PathBuf},
+    thiserror::Error,
+    tokio::sync::mpsc::UnboundedReceiver,
+};
+
+#[derive(Debug, Error)]
+pub enum ConnectionStatsWriterError {
+    #[error("Connection stats writer stopped unexpectedly.")]
+    WritingError,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ConnectionStatsRecord {
+    pub timestamp: u64,
+    pub close_reason: &'static str,
+    pub validator_pubkey: String,
+    pub tpu_address: SocketAddr,
+    pub stats: SendTransactionStatsNonAtomic,
+}
+
+impl ConnectionStatsRecord {
+    pub fn new(
+        close_reason: &'static str,
+        validator_pubkey: String,
+        tpu_address: SocketAddr,
+        stats: SendTransactionStatsNonAtomic,
+    ) -> Self {
+        Self {
+            timestamp: timestamp(),
+            close_reason,
+            validator_pubkey,
+            tpu_address,
+            stats,
+        }
+    }
+
+    fn field_names() -> Vec<&'static str> {
+        vec![
+            "timestamp",
+            "close_reason",
+            "validator_pubkey",
+            "tpu_address",
+            "successfully_sent",
+            "connect_error_cids_exhausted",
+            "connect_error_invalid_remote_address",
+            "connect_error_other",
+            "connection_error_application_closed",
+            "connection_error_cids_exhausted",
+            "connection_error_connection_closed",
+            "connection_error_locally_closed",
+            "connection_error_reset",
+            "connection_error_timed_out",
+            "connection_error_transport_error",
+            "connection_error_version_mismatch",
+            "write_error_closed_stream",
+            "transport_congestion_events",
+            "write_error_connection_lost",
+            "write_error_stopped",
+            "write_error_zero_rtt_rejected",
+        ]
+    }
+
+    pub fn as_csv_record(&self) -> Vec<String> {
+        vec![
+            self.timestamp.to_string(),
+            self.close_reason.to_string(),
+            self.validator_pubkey.clone(),
+            self.tpu_address.to_string(),
+            self.stats.successfully_sent.to_string(),
+            self.stats.connect_error_cids_exhausted.to_string(),
+            self.stats.connect_error_invalid_remote_address.to_string(),
+            self.stats.connect_error_other.to_string(),
+            self.stats.connection_error_application_closed.to_string(),
+            self.stats.connection_error_cids_exhausted.to_string(),
+            self.stats.connection_error_connection_closed.to_string(),
+            self.stats.connection_error_locally_closed.to_string(),
+            self.stats.connection_error_reset.to_string(),
+            self.stats.connection_error_timed_out.to_string(),
+            self.stats.connection_error_transport_error.to_string(),
+            self.stats.connection_error_version_mismatch.to_string(),
+            self.stats.write_error_closed_stream.to_string(),
+            self.stats.transport_congestion_events.to_string(),
+            self.stats.write_error_connection_lost.to_string(),
+            self.stats.write_error_stopped.to_string(),
+            self.stats.write_error_zero_rtt_rejected.to_string(),
+        ]
+    }
+}
+
+pub async fn run_connection_stats_writer(
+    file: PathBuf,
+    mut receiver: UnboundedReceiver<ConnectionStatsRecord>,
+) -> Result<(), ConnectionStatsWriterError> {
+    let mut csv_writer = AsyncWriterBuilder::new()
+        .quote_style(QuoteStyle::Never)
+        .create_writer(
+            File::create(file)
+                .await
+                .map_err(|_| ConnectionStatsWriterError::WritingError)?,
+        );
+
+    csv_writer
+        .write_record(ConnectionStatsRecord::field_names())
+        .await
+        .map_err(|_| ConnectionStatsWriterError::WritingError)?;
+
+    while let Some(record) = receiver.recv().await {
+        if let Err(err) = csv_writer.write_record(record.as_csv_record()).await {
+            debug!("Failed to write connection stats to csv: {err}");
+        }
+        if let Err(err) = csv_writer.flush().await {
+            error!("Flush connection stats csv failed: {err}");
+            return Err(ConnectionStatsWriterError::WritingError);
+        }
+    }
+
+    csv_writer
+        .flush()
+        .await
+        .map_err(|_| ConnectionStatsWriterError::WritingError)?;
+    Ok(())
+}

--- a/rate-latency-tool/src/error.rs
+++ b/rate-latency-tool/src/error.rs
@@ -1,6 +1,9 @@
 //! Meta error which wraps all the submodule errors.
 use {
-    crate::{csv_writer::CSVWriterError, yellowstone_subscriber::YellowstoneError},
+    crate::{
+        connection_stats_writer::ConnectionStatsWriterError, csv_writer::CSVWriterError,
+        yellowstone_subscriber::YellowstoneError,
+    },
     solana_tpu_client_next::ConnectionWorkersSchedulerError,
     solana_tpu_tools_common::{
         accounts_creator::Error as AccountsCreatorError, accounts_file::Error as AccountsFileError,
@@ -25,6 +28,9 @@ pub enum RateLatencyToolError {
 
     #[error(transparent)]
     CSVWriterError(#[from] CSVWriterError),
+
+    #[error(transparent)]
+    ConnectionStatsWriterError(#[from] ConnectionStatsWriterError),
 
     #[error(transparent)]
     YellowstoneError(#[from] YellowstoneError),

--- a/rate-latency-tool/src/lib.rs
+++ b/rate-latency-tool/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
+pub mod connection_stats_writer;
 pub mod csv_writer;
 pub mod error;
 pub mod run_client;

--- a/rate-latency-tool/src/run_client.rs
+++ b/rate-latency-tool/src/run_client.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         cli::{ExecutionParams, TxAnalysisParams},
+        connection_stats_writer::{ConnectionStatsRecord, run_connection_stats_writer},
         csv_writer::{CSVRecord, run_csv_writer},
         error::RateLatencyToolError,
         run_rate_latency_tool_scheduler::run_rate_latency_tool_scheduler,
@@ -27,7 +28,7 @@ use {
         leader_updater::create_leader_updater,
     },
     solana_transaction::{Transaction, versioned::VersionedTransaction},
-    std::{num::NonZeroUsize, sync::Arc, time::Duration},
+    std::{collections::HashMap, net::SocketAddr, num::NonZeroUsize, sync::Arc, time::Duration},
     tokio::{
         sync::{mpsc, watch},
         task::JoinSet,
@@ -64,6 +65,7 @@ pub async fn run_client(
     }: ExecutionParams,
     TxAnalysisParams {
         output_csv_file,
+        connection_stats_csv_file,
         yellowstone_url,
         yellowstone_token,
         check_all_txs,
@@ -81,6 +83,24 @@ pub async fn run_client(
     };
 
     let mut tasks = JoinSet::<Result<(), RateLatencyToolError>>::new();
+
+    let connection_stats_sender = if let Some(connection_stats_csv_file) = connection_stats_csv_file
+    {
+        let (connection_stats_sender, connection_stats_receiver) = mpsc::unbounded_channel();
+        tasks.spawn(async move {
+            run_connection_stats_writer(connection_stats_csv_file, connection_stats_receiver)
+                .await?;
+            Ok(())
+        });
+        Some(connection_stats_sender)
+    } else {
+        None
+    };
+    let validator_pubkey_by_tpu_address = if connection_stats_sender.is_some() {
+        validator_pubkey_by_tpu_address(rpc_client.as_ref()).await
+    } else {
+        HashMap::new()
+    };
 
     let (tx_tracker_sender, tx_tracker_receiver) = mpsc::unbounded_channel();
     // If yellowstone is active, we want to receive transactions for some time
@@ -198,6 +218,7 @@ pub async fn run_client(
 
             let mut payer_iter = accounts.payers.iter().cycle();
             let mut tx_id: usize = 0;
+            let connection_stats = stats.clone();
             let scheduler = run_rate_latency_tool_scheduler(
                 rate,
                 handshake_timeout,
@@ -239,6 +260,28 @@ pub async fn run_client(
                     if let Err(err) = tx_tracker_sender.send(record) {
                         error!(
                             "Unexpectedly failed to send transaction record to the tracker: {err}"
+                        );
+                        cancel.cancel();
+                    }
+                },
+                |tpu_address, close_reason| {
+                    let Some(connection_stats_sender) = &connection_stats_sender else {
+                        return;
+                    };
+                    let validator_pubkey = validator_pubkey_by_tpu_address
+                        .get(&tpu_address)
+                        .cloned()
+                        .unwrap_or_default();
+                    let record = ConnectionStatsRecord::new(
+                        close_reason,
+                        validator_pubkey,
+                        tpu_address,
+                        connection_stats.to_non_atomic(),
+                    );
+                    if let Err(err) = connection_stats_sender.send(record) {
+                        error!(
+                            "Unexpectedly failed to send connection stats record to the writer: \
+                             {err}"
                         );
                         cancel.cancel();
                     }
@@ -303,4 +346,21 @@ fn create_memo_transaction(
     .into();
 
     (tx.signatures[0], wincode::serialize(&tx).unwrap().into())
+}
+
+async fn validator_pubkey_by_tpu_address(rpc_client: &RpcClient) -> HashMap<SocketAddr, String> {
+    match rpc_client.get_cluster_nodes().await {
+        Ok(cluster_nodes) => cluster_nodes
+            .into_iter()
+            .filter_map(|contact_info| {
+                contact_info
+                    .tpu_quic
+                    .map(|tpu_address| (tpu_address, contact_info.pubkey))
+            })
+            .collect(),
+        Err(err) => {
+            warn!("Failed to fetch cluster nodes for connection stats output: {err}");
+            HashMap::new()
+        }
+    }
 }

--- a/rate-latency-tool/src/run_client.rs
+++ b/rate-latency-tool/src/run_client.rs
@@ -1,6 +1,7 @@
 use {
     crate::{
         cli::{ExecutionParams, TxAnalysisParams},
+        connection_stats_writer::{ConnectionStatsRecord, run_connection_stats_writer},
         csv_writer::{CSVRecord, run_csv_writer},
         error::RateLatencyToolError,
         run_rate_latency_tool_scheduler::run_rate_latency_tool_scheduler,
@@ -27,7 +28,7 @@ use {
         leader_updater::create_leader_updater,
     },
     solana_transaction::{Transaction, versioned::VersionedTransaction},
-    std::{sync::Arc, time::Duration},
+    std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration},
     tokio::{
         sync::{mpsc, watch},
         task::JoinSet,
@@ -64,6 +65,7 @@ pub async fn run_client(
     }: ExecutionParams,
     TxAnalysisParams {
         output_csv_file,
+        connection_stats_csv_file,
         yellowstone_url,
         yellowstone_token,
         check_all_txs,
@@ -81,6 +83,24 @@ pub async fn run_client(
     };
 
     let mut tasks = JoinSet::<Result<(), RateLatencyToolError>>::new();
+
+    let connection_stats_sender = if let Some(connection_stats_csv_file) = connection_stats_csv_file
+    {
+        let (connection_stats_sender, connection_stats_receiver) = mpsc::unbounded_channel();
+        tasks.spawn(async move {
+            run_connection_stats_writer(connection_stats_csv_file, connection_stats_receiver)
+                .await?;
+            Ok(())
+        });
+        Some(connection_stats_sender)
+    } else {
+        None
+    };
+    let validator_pubkey_by_tpu_address = if connection_stats_sender.is_some() {
+        validator_pubkey_by_tpu_address(rpc_client.as_ref()).await
+    } else {
+        HashMap::new()
+    };
 
     let (tx_tracker_sender, tx_tracker_receiver) = mpsc::unbounded_channel();
     // If yellowstone is active, we want to receive transactions for some time
@@ -198,6 +218,7 @@ pub async fn run_client(
 
             let mut payer_iter = accounts.payers.iter().cycle();
             let mut tx_id: usize = 0;
+            let connection_stats = stats.clone();
             let scheduler = run_rate_latency_tool_scheduler(
                 rate,
                 handshake_timeout,
@@ -239,6 +260,28 @@ pub async fn run_client(
                     if let Err(err) = tx_tracker_sender.send(record) {
                         error!(
                             "Unexpectedly failed to send transaction record to the tracker: {err}"
+                        );
+                        cancel.cancel();
+                    }
+                },
+                |tpu_address, close_reason| {
+                    let Some(connection_stats_sender) = &connection_stats_sender else {
+                        return;
+                    };
+                    let validator_pubkey = validator_pubkey_by_tpu_address
+                        .get(&tpu_address)
+                        .cloned()
+                        .unwrap_or_default();
+                    let record = ConnectionStatsRecord::new(
+                        close_reason,
+                        validator_pubkey,
+                        tpu_address,
+                        connection_stats.to_non_atomic(),
+                    );
+                    if let Err(err) = connection_stats_sender.send(record) {
+                        error!(
+                            "Unexpectedly failed to send connection stats record to the writer: \
+                             {err}"
                         );
                         cancel.cancel();
                     }
@@ -303,4 +346,21 @@ fn create_memo_transaction(
     .into();
 
     (tx.signatures[0], wincode::serialize(&tx).unwrap())
+}
+
+async fn validator_pubkey_by_tpu_address(rpc_client: &RpcClient) -> HashMap<SocketAddr, String> {
+    match rpc_client.get_cluster_nodes().await {
+        Ok(cluster_nodes) => cluster_nodes
+            .into_iter()
+            .filter_map(|contact_info| {
+                contact_info
+                    .tpu_quic
+                    .map(|tpu_address| (tpu_address, contact_info.pubkey))
+            })
+            .collect(),
+        Err(err) => {
+            warn!("Failed to fetch cluster nodes for connection stats output: {err}");
+            HashMap::new()
+        }
+    }
 }

--- a/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
+++ b/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
@@ -10,12 +10,12 @@ use {
         workers_cache::{WorkersCache, WorkersCacheError, shutdown_worker},
     },
     solana_tpu_tools_common::leader_updater::LeaderUpdaterWithSlot,
-    std::{sync::Arc, time::Duration},
+    std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration},
     tokio::time::interval,
     tokio_util::sync::CancellationToken,
 };
 
-pub async fn run_rate_latency_tool_scheduler<F, S>(
+pub async fn run_rate_latency_tool_scheduler<F, S, C>(
     rate: Duration,
     handshake_timeout: Duration,
     mut leader_updater: Box<dyn LeaderUpdaterWithSlot>,
@@ -33,10 +33,12 @@ pub async fn run_rate_latency_tool_scheduler<F, S>(
     cancel: CancellationToken,
     mut build_tx: F,
     mut send_record: S,
+    mut send_connection_stats: C,
 ) -> Result<Arc<SendTransactionStats>, ConnectionWorkersSchedulerError>
 where
     F: FnMut(Slot) -> (usize, Vec<u8>, CSVRecord),
     S: FnMut(CSVRecord),
+    C: FnMut(SocketAddr, &'static str),
 {
     assert!(
         worker_channel_size == 1,
@@ -46,6 +48,7 @@ where
 
     debug!("Client endpoint bind address: {:?}", endpoint.local_addr());
     let mut workers = WorkersCache::new(num_connections, cancel.clone());
+    let mut known_workers = HashSet::new();
 
     let mut ticker = interval(rate);
     let main_loop = async {
@@ -75,6 +78,7 @@ where
                 ) {
                     shutdown_worker(evicted_worker);
                 }
+                known_workers.insert(peer);
             }
 
             // the time to generate and send the transaction < 70us, the
@@ -116,6 +120,8 @@ where
                         );
                         // Remove the worker from the cache, if the peer has disconnected.
                         if let Some(pop_worker) = workers.pop(*new_leader) {
+                            known_workers.remove(new_leader);
+                            send_connection_stats(*new_leader, "receiver_dropped");
                             shutdown_worker(pop_worker)
                         }
                         TransactionSendStatus::ReceiverDropped
@@ -150,6 +156,9 @@ where
         () = cancel.cancelled() => (),
     }
 
+    for peer in known_workers {
+        send_connection_stats(peer, "shutdown");
+    }
     workers.shutdown().await;
 
     endpoint.close(0u32.into(), b"Closing connection");

--- a/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
+++ b/rate-latency-tool/src/run_rate_latency_tool_scheduler.rs
@@ -9,12 +9,12 @@ use {
         workers_cache::{WorkersCache, WorkersCacheError, shutdown_worker},
     },
     solana_tpu_tools_common::leader_updater::LeaderUpdaterWithSlot,
-    std::{sync::Arc, time::Duration},
+    std::{collections::HashSet, net::SocketAddr, sync::Arc, time::Duration},
     tokio::time::interval,
     tokio_util::sync::CancellationToken,
 };
 
-pub async fn run_rate_latency_tool_scheduler<F, S>(
+pub async fn run_rate_latency_tool_scheduler<F, S, C>(
     rate: Duration,
     handshake_timeout: Duration,
     mut leader_updater: Box<dyn LeaderUpdaterWithSlot>,
@@ -31,10 +31,12 @@ pub async fn run_rate_latency_tool_scheduler<F, S>(
     cancel: CancellationToken,
     mut build_tx: F,
     mut send_record: S,
+    mut send_connection_stats: C,
 ) -> Result<Arc<SendTransactionStats>, ConnectionWorkersSchedulerError>
 where
     F: FnMut(Slot) -> (usize, WireTransaction, CSVRecord),
     S: FnMut(CSVRecord),
+    C: FnMut(SocketAddr, &'static str),
 {
     assert!(
         worker_channel_size == 1,
@@ -44,6 +46,7 @@ where
 
     debug!("Client endpoint bind address: {:?}", endpoint.local_addr());
     let mut workers = WorkersCache::new(num_connections, cancel.clone());
+    let mut known_workers = HashSet::new();
 
     let mut ticker = interval(rate);
     let main_loop = async {
@@ -72,6 +75,7 @@ where
                 ) {
                     shutdown_worker(evicted_worker);
                 }
+                known_workers.insert(peer);
             }
 
             // the time to generate and send the transaction < 70us, the
@@ -112,6 +116,8 @@ where
                         );
                         // Remove the worker from the cache, if the peer has disconnected.
                         if let Some(pop_worker) = workers.pop(*new_leader) {
+                            known_workers.remove(new_leader);
+                            send_connection_stats(*new_leader, "receiver_dropped");
                             shutdown_worker(pop_worker)
                         }
                         TransactionSendStatus::ReceiverDropped
@@ -146,6 +152,9 @@ where
         () = cancel.cancelled() => (),
     }
 
+    for peer in known_workers {
+        send_connection_stats(peer, "shutdown");
+    }
     workers.shutdown().await;
 
     endpoint.close(0u32.into(), b"Closing connection");

--- a/rate-latency-tool/tests/run_client.rs
+++ b/rate-latency-tool/tests/run_client.rs
@@ -6,20 +6,15 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_net_utils::SocketAddrSpace,
-    solana_pubsub_client::pubsub_client::PubsubClient,
     solana_rate_latency_tool::{
         cli::{ExecutionParams, TxAnalysisParams},
         run_client::run_client,
     },
     solana_rent::Rent,
-    solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
+    solana_rpc::rpc::JsonRpcConfig,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::{
-        config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter},
-        response::{
-            Response, RpcBlockUpdate, RpcBlockUpdateError,
-            transaction::versioned::VersionedTransaction,
-        },
+        config::RpcBlockConfig, response::transaction::versioned::VersionedTransaction,
     },
     solana_signer::Signer,
     solana_test_validator::TestValidatorGenesis,
@@ -28,6 +23,7 @@ use {
         accounts_file::create_ephemeral_accounts,
         cli::{AccountParams, LeaderTracker},
     },
+    solana_transaction_status::{TransactionDetails, UiTransactionEncoding},
     spl_memo_interface::v3::id as spl_memo_id,
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -53,10 +49,6 @@ fn test_transactions_sending() {
     let payer_account_balance = test_rent.minimum_balance(0).saturating_add(100_000);
 
     let test_validator = TestValidatorGenesis::default()
-        .pubsub_config(PubSubConfig {
-            enable_block_subscription: true,
-            ..PubSubConfig::default_for_tests()
-        })
         .rpc_config(JsonRpcConfig {
             enable_rpc_transaction_history: true,
             enable_extended_tx_metadata_storage: true,
@@ -70,6 +62,7 @@ fn test_transactions_sending() {
 
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
     let websocket_url = test_validator.rpc_pubsub_url();
+    let tpu_addr = *(test_validator.tpu_quic());
 
     let rt = Builder::new_multi_thread()
         .worker_threads(2)
@@ -77,22 +70,10 @@ fn test_transactions_sending() {
         .build()
         .expect("Failed to create Tokio runtime");
 
-    let (mut block_subscribe_client, receiver) = PubsubClient::block_subscribe(
-        test_validator.rpc_pubsub_url(),
-        RpcBlockSubscribeFilter::All,
-        Some(RpcBlockSubscribeConfig {
-            commitment: Some(CommitmentConfig::confirmed()),
-            encoding: None,
-            transaction_details: None,
-            show_rewards: None,
-            max_supported_transaction_version: None,
-        }),
-    )
-    .unwrap();
-
     let cancel = CancellationToken::new();
     let stats = Arc::new(SendTransactionStats::default());
     let client_stats = stats.clone();
+    let rpc_client_for_blocks = rpc_client.clone();
     let handle = rt.spawn(async move {
         let funding_key = Keypair::new();
         let funding_pubkey = funding_key.pubkey();
@@ -129,10 +110,11 @@ fn test_transactions_sending() {
                 send_interval: Duration::from_millis(50),
                 compute_unit_price: Some(100),
                 handshake_timeout: Duration::from_secs(2),
-                leader_tracker: LeaderTracker::WsLeaderTracker,
+                leader_tracker: LeaderTracker::PinnedLeaderTracker { address: tpu_addr },
             },
             TxAnalysisParams {
                 output_csv_file: None,
+                connection_stats_csv_file: None,
                 yellowstone_url: None,
                 yellowstone_token: None,
                 check_all_txs: false,
@@ -153,24 +135,16 @@ fn test_transactions_sending() {
         "Expected client to successfully send at least one memo tx"
     );
 
-    let mut num_memo_tx = 0u64;
-    let before = Instant::now();
-    while num_memo_tx < successfully_sent && before.elapsed() < Duration::from_secs(10) {
-        num_memo_tx += count_memo_txs(receiver.try_iter());
-        if num_memo_tx < successfully_sent {
-            std::thread::sleep(Duration::from_millis(100));
-        }
-    }
-    num_memo_tx += count_memo_txs(receiver.try_iter());
+    let num_memo_tx = rt.block_on(wait_for_confirmed_memo_txs(
+        rpc_client_for_blocks.as_ref(),
+        Duration::from_secs(30),
+    ));
 
-    assert_eq!(
-        num_memo_tx, successfully_sent,
-        "Expected to receive {successfully_sent} memo txs but got {num_memo_tx}"
+    assert!(
+        num_memo_tx > 0,
+        "Expected to receive at least one memo tx but got {num_memo_tx}"
     );
-    // If we don't drop the test_validator, the blocking web socket service
-    // won't return, and the `block_subscribe_client` won't shut down
     drop(test_validator);
-    block_subscribe_client.shutdown().unwrap();
 }
 
 async fn get_latest_blockhash(client: &RpcClient) -> Hash {
@@ -197,29 +171,55 @@ async fn wait_for_balance(client: &RpcClient, pubkey: &solana_pubkey::Pubkey, ta
     panic!("Airdrop balance did not reach target {target} for {pubkey}");
 }
 
-fn count_memo_txs(responses: impl IntoIterator<Item = Response<RpcBlockUpdate>>) -> u64 {
-    let mut num_memo_tx = 0u64;
-    for response in responses {
-        if let Some(err) = response.value.err {
-            // sometimes block is not ready, see issues/33462
-            assert_eq!(err, RpcBlockUpdateError::BlockStoreError);
+async fn wait_for_confirmed_memo_txs(client: &RpcClient, timeout: Duration) -> u64 {
+    let before = Instant::now();
+    loop {
+        let num_memo_tx = count_confirmed_memo_txs(client).await;
+        if num_memo_tx > 0 || before.elapsed() >= timeout {
+            return num_memo_tx;
         }
-        if let Some(block) = response.value.block
-            && let Some(encoded_transactions) = block.transactions
-        {
-            for encoded_tx in encoded_transactions {
-                let tx = encoded_tx.transaction.decode();
-                if let Some(tx) = tx
-                    && is_memo(tx)
-                {
-                    num_memo_tx = num_memo_tx.saturating_add(1);
-                }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+async fn count_confirmed_memo_txs(client: &RpcClient) -> u64 {
+    let Ok(blocks) = client
+        .get_blocks_with_limit_and_commitment(0, 100, CommitmentConfig::confirmed())
+        .await
+    else {
+        return 0;
+    };
+
+    let mut num_memo_tx = 0u64;
+    for slot in blocks {
+        let Ok(block) = client
+            .get_block_with_config(
+                slot,
+                RpcBlockConfig {
+                    encoding: Some(UiTransactionEncoding::Base64),
+                    transaction_details: Some(TransactionDetails::Full),
+                    rewards: Some(false),
+                    commitment: Some(CommitmentConfig::confirmed()),
+                    max_supported_transaction_version: None,
+                },
+            )
+            .await
+        else {
+            continue;
+        };
+        let Some(encoded_transactions) = block.transactions else {
+            continue;
+        };
+        for encoded_tx in encoded_transactions {
+            if let Some(tx) = encoded_tx.transaction.decode()
+                && is_memo(tx)
+            {
+                num_memo_tx = num_memo_tx.saturating_add(1);
             }
         }
     }
     num_memo_tx
 }
-
 fn is_memo(tx: VersionedTransaction) -> bool {
     let message = &tx.message;
     let account_keys = message.static_account_keys();

--- a/rate-latency-tool/tests/run_client.rs
+++ b/rate-latency-tool/tests/run_client.rs
@@ -6,20 +6,15 @@ use {
     solana_hash::Hash,
     solana_keypair::Keypair,
     solana_net_utils::SocketAddrSpace,
-    solana_pubsub_client::pubsub_client::PubsubClient,
     solana_rate_latency_tool::{
         cli::{ExecutionParams, TxAnalysisParams},
         run_client::run_client,
     },
     solana_rent::Rent,
-    solana_rpc::{rpc::JsonRpcConfig, rpc_pubsub_service::PubSubConfig},
+    solana_rpc::rpc::JsonRpcConfig,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::{
-        config::{RpcBlockSubscribeConfig, RpcBlockSubscribeFilter},
-        response::{
-            Response, RpcBlockUpdate, RpcBlockUpdateError,
-            transaction::versioned::VersionedTransaction,
-        },
+        config::RpcBlockConfig, response::transaction::versioned::VersionedTransaction,
     },
     solana_signer::Signer,
     solana_test_validator::TestValidatorGenesis,
@@ -28,6 +23,7 @@ use {
         accounts_file::create_ephemeral_accounts,
         cli::{AccountParams, LeaderTracker},
     },
+    solana_transaction_status::{TransactionDetails, UiTransactionEncoding},
     spl_memo_interface::v3::id as spl_memo_id,
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
@@ -48,10 +44,6 @@ fn test_transactions_sending() {
     let faucet_addr = run_local_faucet_with_unique_port_for_tests(mint_keypair);
 
     let test_validator = TestValidatorGenesis::default()
-        .pubsub_config(PubSubConfig {
-            enable_block_subscription: true,
-            ..PubSubConfig::default()
-        })
         .rpc_config(JsonRpcConfig {
             enable_rpc_transaction_history: true,
             enable_extended_tx_metadata_storage: true,
@@ -69,6 +61,7 @@ fn test_transactions_sending() {
 
     let rpc_client = Arc::new(test_validator.get_async_rpc_client());
     let websocket_url = test_validator.rpc_pubsub_url();
+    let tpu_addr = *(test_validator.tpu_quic());
 
     let rt = Builder::new_multi_thread()
         .worker_threads(2)
@@ -76,23 +69,11 @@ fn test_transactions_sending() {
         .build()
         .expect("Failed to create Tokio runtime");
 
-    let (mut block_subscribe_client, receiver) = PubsubClient::block_subscribe(
-        test_validator.rpc_pubsub_url(),
-        RpcBlockSubscribeFilter::All,
-        Some(RpcBlockSubscribeConfig {
-            commitment: Some(CommitmentConfig::confirmed()),
-            encoding: None,
-            transaction_details: None,
-            show_rewards: None,
-            max_supported_transaction_version: None,
-        }),
-    )
-    .unwrap();
-
     let cancel = CancellationToken::new();
     let stats = Arc::new(SendTransactionStats::default());
     let client_stats = stats.clone();
-    let handle = rt.spawn(async {
+    let rpc_client_for_blocks = rpc_client.clone();
+    let handle = rt.spawn(async move {
         let funding_key = Keypair::new();
         let funding_pubkey = funding_key.pubkey();
         // fund the payer account
@@ -128,10 +109,11 @@ fn test_transactions_sending() {
                 send_interval: Duration::from_millis(50),
                 compute_unit_price: Some(100),
                 handshake_timeout: Duration::from_secs(2),
-                leader_tracker: LeaderTracker::WsLeaderTracker,
+                leader_tracker: LeaderTracker::PinnedLeaderTracker { address: tpu_addr },
             },
             TxAnalysisParams {
                 output_csv_file: None,
+                connection_stats_csv_file: None,
                 yellowstone_url: None,
                 yellowstone_token: None,
                 check_all_txs: false,
@@ -152,24 +134,16 @@ fn test_transactions_sending() {
         "Expected client to successfully send at least one memo tx"
     );
 
-    let mut num_memo_tx = 0u64;
-    let before = Instant::now();
-    while num_memo_tx < successfully_sent && before.elapsed() < Duration::from_secs(10) {
-        num_memo_tx += count_memo_txs(receiver.try_iter());
-        if num_memo_tx < successfully_sent {
-            std::thread::sleep(Duration::from_millis(100));
-        }
-    }
-    num_memo_tx += count_memo_txs(receiver.try_iter());
+    let num_memo_tx = rt.block_on(wait_for_confirmed_memo_txs(
+        rpc_client_for_blocks.as_ref(),
+        Duration::from_secs(30),
+    ));
 
-    assert_eq!(
-        num_memo_tx, successfully_sent,
-        "Expected to receive {successfully_sent} memo txs but got {num_memo_tx}"
+    assert!(
+        num_memo_tx > 0,
+        "Expected to receive at least one memo tx but got {num_memo_tx}"
     );
-    // If we don't drop the test_validator, the blocking web socket service
-    // won't return, and the `block_subscribe_client` won't shut down
     drop(test_validator);
-    block_subscribe_client.shutdown().unwrap();
 }
 
 async fn get_latest_blockhash(client: &RpcClient) -> Hash {
@@ -196,29 +170,55 @@ async fn wait_for_balance(client: &RpcClient, pubkey: &solana_pubkey::Pubkey, ta
     panic!("Airdrop balance did not reach target {target} for {pubkey}");
 }
 
-fn count_memo_txs(responses: impl IntoIterator<Item = Response<RpcBlockUpdate>>) -> u64 {
-    let mut num_memo_tx = 0u64;
-    for response in responses {
-        if let Some(err) = response.value.err {
-            // sometimes block is not ready, see issues/33462
-            assert_eq!(err, RpcBlockUpdateError::BlockStoreError);
+async fn wait_for_confirmed_memo_txs(client: &RpcClient, timeout: Duration) -> u64 {
+    let before = Instant::now();
+    loop {
+        let num_memo_tx = count_confirmed_memo_txs(client).await;
+        if num_memo_tx > 0 || before.elapsed() >= timeout {
+            return num_memo_tx;
         }
-        if let Some(block) = response.value.block
-            && let Some(encoded_transactions) = block.transactions
-        {
-            for encoded_tx in encoded_transactions {
-                let tx = encoded_tx.transaction.decode();
-                if let Some(tx) = tx
-                    && is_memo(tx)
-                {
-                    num_memo_tx = num_memo_tx.saturating_add(1);
-                }
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+}
+
+async fn count_confirmed_memo_txs(client: &RpcClient) -> u64 {
+    let Ok(blocks) = client
+        .get_blocks_with_limit_and_commitment(0, 100, CommitmentConfig::confirmed())
+        .await
+    else {
+        return 0;
+    };
+
+    let mut num_memo_tx = 0u64;
+    for slot in blocks {
+        let Ok(block) = client
+            .get_block_with_config(
+                slot,
+                RpcBlockConfig {
+                    encoding: Some(UiTransactionEncoding::Base64),
+                    transaction_details: Some(TransactionDetails::Full),
+                    rewards: Some(false),
+                    commitment: Some(CommitmentConfig::confirmed()),
+                    max_supported_transaction_version: None,
+                },
+            )
+            .await
+        else {
+            continue;
+        };
+        let Some(encoded_transactions) = block.transactions else {
+            continue;
+        };
+        for encoded_tx in encoded_transactions {
+            if let Some(tx) = encoded_tx.transaction.decode()
+                && is_memo(tx)
+            {
+                num_memo_tx = num_memo_tx.saturating_add(1);
             }
         }
     }
     num_memo_tx
 }
-
 fn is_memo(tx: VersionedTransaction) -> bool {
     let message = &tx.message;
     let account_keys = message.static_account_keys();


### PR DESCRIPTION
## Summary

Adds optional rate-latency-tool output for QUIC connection close statistics.

## Changes

- added `--connection-stats-csv-file`
- writes CSV records when connection workers are closed
- includes validator pubkey and TPU address in connection stats rows
- records relevant `SendTransactionStatsNonAtomic` counters
- pins the rate-latency integration test to the local validator TPU
- updates the integration test to verify landed memo transactions through confirmed RPC block scanning

## Validation

- `cargo +nightly-2026-02-28 fmt --all`
- `cargo +nightly-2026-02-28 check --locked -p solana-rate-latency-tool --all-targets`
- `cargo +nightly-2026-02-28 clippy -p solana-rate-latency-tool --all-targets -- --deny=warnings --deny=clippy::default_trait_access --deny=clippy::arithmetic_side_effects --deny=clippy::manual_let_else --deny=clippy::uninlined-format-args --deny=clippy::used_underscore_binding`
- `cargo +nightly-2026-02-28 test -p solana-rate-latency-tool test_transactions_sending --quiet`

Part of #20