### PR TITLE
remove send batching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8312,15 +8312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "solana-quic-definitions"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15319accf7d3afd845817aeffa6edd8cc185f135cefbc6b985df29cfd8c09609"
-dependencies = [
- "solana-keypair",
-]
-
-[[package]]
 name = "solana-rate-latency-tool"
 version = "0.1.0"
 dependencies = [
@@ -8353,7 +8344,6 @@ dependencies = [
  "solana-net-utils",
  "solana-pubkey 4.3.0",
  "solana-pubsub-client",
- "solana-quic-definitions",
  "solana-rent",
  "solana-rpc",
  "solana-rpc-client",
@@ -9700,7 +9690,6 @@ dependencies = [
  "solana-net-utils",
  "solana-pubkey 4.3.0",
  "solana-pubsub-client",
- "solana-quic-definitions",
  "solana-rent",
  "solana-rpc",
  "solana-rpc-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,6 @@ solana-native-token = "=3.0.0"
 solana-net-utils = { version = "=4.3.0-beta.0", features = ["agave-unstable-api"] }
 solana-pubkey = { version = "=4.3.0", default-features = false }
 solana-pubsub-client = { version = "=4.3.0-beta.0" }
-solana-quic-definitions = "3.0.0"
 solana-rent = "=4.4.0"
 solana-rpc = { version = "=4.3.0-beta.0", features = ["agave-unstable-api"] }
 solana-rpc-client = { version = "=4.3.0-beta.0", default-features = false }

--- a/rate-latency-tool/Cargo.toml
+++ b/rate-latency-tool/Cargo.toml
@@ -38,7 +38,6 @@ solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-pubsub-client = { workspace = true, optional = true }
-solana-quic-definitions = { workspace = true, optional = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
 solana-sdk-ids = { workspace = true }

--- a/transaction-bench/Cargo.toml
+++ b/transaction-bench/Cargo.toml
@@ -40,7 +40,6 @@ solana-measure = { workspace = true }
 solana-message = { workspace = true }
 solana-metrics = { workspace = true }
 solana-pubkey = { workspace = true }
-solana-quic-definitions = { workspace = true }
 solana-rent = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }

--- a/transaction-bench/README.md
+++ b/transaction-bench/README.md
@@ -118,10 +118,9 @@ solana-transaction-bench "${args[@]}"
 #### Target TPS
 
 Use `--target-tps` to pace transaction generation instead of sending as fast as
-the generator and connection workers allow. When `--target-tps` is set and
-`--tx-batch-size` is not set, the tool chooses a batch size for roughly 10
-batches per second and adjusts the generator worker count for the requested
-rate.
+the generator and connection workers allow. Transaction batches are a generator
+concern only; `--tx-batch-size` controls how many transactions are produced per
+generated batch and defaults to 64.
 
 ```shell
 args=(
@@ -216,8 +215,9 @@ solana -u "$URL" program deploy spl_instruction_padding.so --program-id spl_inst
 
 #### Transaction Conflicts
 
-Use `--tx-batch-size` with `--num-conflict-groups` to intentionally reuse destination accounts
-within each generated batch. Lower conflict group counts create more account conflicts.
+Use `--num-conflict-groups` to intentionally reuse destination accounts within each generated
+batch. Lower conflict group counts create more account conflicts. Use `--tx-batch-size` to change
+the generated batch size from its default of 64.
 `--num-conflict-groups` must be no greater than `--num-send-instructions-per-tx * --tx-batch-size`.
 
 ```shell

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -215,11 +215,12 @@ pub struct ExecutionParams {
 
     #[clap(
         long,
-        default_value_t = 8,
+        default_value = "8",
+        value_parser = value_parser!(NonZeroUsize),
         help = "Size of the workers pull, controls how many transactions batches are generated in \
                 parallel."
     )]
-    pub workers_pull_size: usize,
+    pub workers_pull_size: NonZeroUsize,
 
     #[clap(
         long,
@@ -371,18 +372,22 @@ pub struct SimpleTransferTxParams {
 
     #[clap(
         long,
+        default_value = "64",
         value_parser = value_parser!(NonZeroUsize),
-        help = "Number of transactions per batch. Required when using --num-conflict-groups."
+        help = "Number of transactions per generated batch. This also affects the maximum valid \
+        --num-conflict-groups value: num-send-instructions-per-tx * tx-batch-size."
     )]
-    pub tx_batch_size: Option<NonZeroUsize>,
+    pub tx_batch_size: NonZeroUsize,
 
     #[clap(
         long,
-        requires = "tx_batch_size",
         value_parser = value_parser!(NonZeroUsize),
         help = "Number of unique destination accounts per batch.\n\
                 When set, destinations repeat to create account conflicts.\n\
-                Lower value = more conflicts. Default: all destinations unique."
+                Lower value = more conflicts. Default: all destinations unique.\n\
+                Destinations are reused cyclically across all transfer instructions\n\
+                in the batch, so lower values create more account conflicts.\n\
+                Must be <= num-send-instructions-per-tx * tx-batch-size."
     )]
     pub num_conflict_groups: Option<NonZeroUsize>,
 }
@@ -498,7 +503,7 @@ mod tests {
                     address: SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8009),
                 },
                 num_max_open_connections: 16,
-                workers_pull_size: 8,
+                workers_pull_size: NonZeroUsize::new(8).unwrap(),
                 send_fanout: 2,
                 compute_unit_price: Some(1000),
                 priority_fee_params: PriorityFeeParams {
@@ -538,7 +543,7 @@ mod tests {
                         max_lamports_to_transfer: 1000,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
-                        tx_batch_size: None,
+                        tx_batch_size: NonZeroUsize::new(64).unwrap(),
                         num_conflict_groups: None,
                     },
                     padding_params: InstructionPaddingParams {
@@ -593,7 +598,7 @@ mod tests {
                         max_lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                         transfer_tx_cu_budget: 1000,
                         num_send_instructions_per_tx: 2,
-                        tx_batch_size: None,
+                        tx_batch_size: NonZeroUsize::new(64).unwrap(),
                         num_conflict_groups: None,
                     },
                     padding_params: InstructionPaddingParams {
@@ -622,7 +627,7 @@ mod tests {
                 max_lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx: 1,
-                tx_batch_size: None,
+                tx_batch_size: NonZeroUsize::new(64).unwrap(),
                 num_conflict_groups: None,
             },
             padding_params: InstructionPaddingParams {
@@ -907,7 +912,7 @@ mod tests {
     }
 
     #[test]
-    fn test_conflict_groups_requires_tx_batch_size() {
+    fn test_conflict_groups_accepts_default_tx_batch_size() {
         let keypair_file_name = "/home/testUser/masterKey.json";
         let (account_args, _account_params) = get_common_account_params();
         let (exec_args, _execution_params) = get_common_execution_params(keypair_file_name);
@@ -921,11 +926,11 @@ mod tests {
         args.extend(exec_args.iter());
         assert!(ClientCliParameters::try_parse_from(args).is_ok());
 
-        // err: num-conflict-groups without tx-batch-size
+        // ok: num-conflict-groups uses the default generated batch size.
         let mut args = base_args.clone();
         args.extend(["--num-conflict-groups", "4"]);
         args.extend(exec_args.iter());
-        assert!(ClientCliParameters::try_parse_from(args).is_err());
+        assert!(ClientCliParameters::try_parse_from(args).is_ok());
 
         // err: num-conflict-groups = 0
         let mut args = base_args.clone();

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -2,6 +2,7 @@
 use {
     crate::{
         cli::{SimpleTransferTxParams, TransactionParams},
+        error::BenchClientError,
         generator::simple_transfers_generator::{SharedSlice, generate_transfer_transaction_batch},
         priority_fee::{PriorityFeeMode, PriorityFeeStats},
     },
@@ -11,7 +12,7 @@ use {
     solana_measure::measure::Measure,
     solana_tpu_client_next::WireTransaction,
     solana_tpu_tools_common::accounts_file::AccountsFile,
-    std::{num::NonZeroU64, sync::Arc},
+    std::{num::NonZeroUsize, sync::Arc},
     thiserror::Error,
     tokio::{
         sync::{mpsc::Sender, watch},
@@ -41,10 +42,10 @@ pub struct TransactionGenerator {
     compute_unit_price: Option<u64>,
     priority_fee_mode: PriorityFeeMode,
     priority_fee_stats: Arc<PriorityFeeStats>,
-    send_batch_size: usize,
     run_duration: Option<Duration>,
-    num_transactions: Option<NonZeroU64>,
-    target_tps: Option<NonZeroU64>,
+    num_transactions: Option<u64>,
+    target_tps: Option<u64>,
+    generate_tx_batch_size: usize,
     workers_pull_size: usize,
 }
 
@@ -58,10 +59,10 @@ impl TransactionGenerator {
         compute_unit_price: Option<u64>,
         priority_fee_mode: PriorityFeeMode,
         priority_fee_stats: Arc<PriorityFeeStats>,
-        send_batch_size: usize,
         duration: Option<Duration>,
-        num_transactions: Option<NonZeroU64>,
-        target_tps: Option<NonZeroU64>,
+        num_transactions: Option<u64>,
+        target_tps: Option<u64>,
+        generate_tx_batch_size: usize,
         workers_pull_size: usize,
     ) -> Self {
         Self {
@@ -72,10 +73,10 @@ impl TransactionGenerator {
             compute_unit_price,
             priority_fee_mode,
             priority_fee_stats,
-            send_batch_size,
             run_duration: duration,
             num_transactions,
             target_tps,
+            generate_tx_batch_size,
             workers_pull_size,
         }
     }
@@ -142,9 +143,11 @@ impl TransactionGenerator {
                 if let Some(next_batch_deadline) = next_batch_at {
                     tokio::time::sleep_until(next_batch_deadline).await;
                 }
-                let Some(send_batch_size) =
-                    next_batch_size(self.num_transactions, self.send_batch_size, txs_scheduled)
-                else {
+                let Some(send_batch_size) = next_batch_size(
+                    self.num_transactions,
+                    self.generate_tx_batch_size,
+                    txs_scheduled,
+                ) else {
                     break;
                 };
                 txs_scheduled = txs_scheduled.saturating_add(send_batch_size as u64);
@@ -276,13 +279,13 @@ async fn send_batch(
 /// (`--duration` or `--num-transactions`) has been reached.
 fn stop_reason(
     run_duration: Option<Duration>,
-    num_transactions: Option<NonZeroU64>,
+    num_transactions: Option<u64>,
     elapsed: Duration,
     txs_scheduled: u64,
 ) -> Option<&'static str> {
     if run_duration.is_some_and(|run_duration| elapsed >= run_duration) {
         Some("duration reached")
-    } else if num_transactions.is_some_and(|budget| txs_scheduled >= budget.get()) {
+    } else if num_transactions.is_some_and(|budget| txs_scheduled >= budget) {
         Some("requested tx count reached")
     } else {
         None
@@ -292,22 +295,22 @@ fn stop_reason(
 /// Number of transactions to schedule in the next batch, or `None` when the
 /// `--num-transactions` budget is exhausted.
 fn next_batch_size(
-    num_transactions: Option<NonZeroU64>,
+    num_transactions: Option<u64>,
     send_batch_size: usize,
     txs_scheduled: u64,
 ) -> Option<usize> {
     let Some(budget) = num_transactions else {
         return Some(send_batch_size);
     };
-    let remaining = budget.get().saturating_sub(txs_scheduled);
+    let remaining = budget.saturating_sub(txs_scheduled);
     // The min() with send_batch_size makes the cast back to usize lossless.
     (remaining > 0).then(|| remaining.min(send_batch_size as u64) as usize)
 }
 
 #[allow(clippy::arithmetic_side_effects)]
-fn compute_batch_interval(send_batch_size: usize, target_tps: NonZeroU64) -> Duration {
+fn compute_batch_interval(send_batch_size: usize, target_tps: u64) -> Duration {
     let send_batch_size = u128::try_from(send_batch_size).unwrap_or(u128::MAX);
-    let target_tps = u128::from(target_tps.get());
+    let target_tps = u128::from(target_tps);
     let batch_interval_nanos = (send_batch_size * 1_000_000_000).div_ceil(target_tps);
     Duration::from_nanos(u64::try_from(batch_interval_nanos).unwrap_or(u64::MAX))
 }
@@ -340,25 +343,40 @@ fn next_lamports_slice(
     lamports
 }
 
+pub(crate) fn check_num_conflict_groups(
+    num_conflict_groups: Option<NonZeroUsize>,
+    num_send_instructions_per_tx: usize,
+    generate_tx_batch_size: usize,
+) -> Result<(), BenchClientError> {
+    let Some(num_conflict_groups) = num_conflict_groups else {
+        return Ok(());
+    };
+    let max_groups = num_send_instructions_per_tx.saturating_mul(generate_tx_batch_size);
+    let num_conflict_groups = num_conflict_groups.get();
+
+    if num_conflict_groups > max_groups {
+        return Err(BenchClientError::InvalidCliArguments(format!(
+            "--num-conflict-groups ({num_conflict_groups}) must be <= \
+             num-send-instructions-per-tx ({num_send_instructions_per_tx}) * tx-batch-size \
+             ({generate_tx_batch_size})"
+        )));
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use {
         super::{compute_batch_interval, compute_transfer_tx_min_cu_budget, next_lamports_slice},
         crate::cli::{InstructionPaddingParams, SimpleTransferTxParams, TransactionParams},
-        std::{num::NonZeroU64, sync::Arc},
+        std::{num::NonZeroUsize, sync::Arc},
         tokio::time::Duration,
     };
 
     #[test]
     fn test_compute_batch_interval() {
-        assert_eq!(
-            compute_batch_interval(10, NonZeroU64::new(100).unwrap()),
-            Duration::from_millis(100)
-        );
-        assert_eq!(
-            compute_batch_interval(1, NonZeroU64::new(1).unwrap()),
-            Duration::from_secs(1)
-        );
+        assert_eq!(compute_batch_interval(10, 100), Duration::from_millis(100));
+        assert_eq!(compute_batch_interval(1, 1), Duration::from_secs(1));
     }
 
     #[test]
@@ -404,19 +422,6 @@ mod tests {
         assert_eq!(index, 4);
     }
 
-    #[test]
-    fn test_next_lamports_slice_reshuffles_when_tail_is_too_short() {
-        let mut pool: Arc<[u64]> = Arc::from([1, 2, 3, 4]);
-        let mut index = 0;
-
-        let old_slice = next_lamports_slice(&mut pool, &mut index, 3);
-        let new_slice = next_lamports_slice(&mut pool, &mut index, 3);
-
-        assert_eq!(old_slice.as_slice(), &[1, 2, 3]);
-        assert_eq!(new_slice.as_slice().len(), 3);
-        assert_eq!(index, 3);
-    }
-
     fn make_transaction_params(
         num_send_instructions_per_tx: usize,
         instruction_padding_data_size: Option<u32>,
@@ -427,7 +432,7 @@ mod tests {
                 max_lamports_to_transfer: 513,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx,
-                tx_batch_size: None,
+                tx_batch_size: NonZeroUsize::new(64).unwrap(),
                 num_conflict_groups: None,
             },
             padding_params: InstructionPaddingParams {

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -311,7 +311,10 @@ mod tests {
             ExecutionParams, InstructionPaddingParams, PriorityFeeParams, SimpleTransferTxParams,
             TransactionParams,
         },
-        std::net::{IpAddr, Ipv4Addr, SocketAddr},
+        std::{
+            net::{IpAddr, Ipv4Addr, SocketAddr},
+            num::NonZeroUsize,
+        },
     };
 
     fn test_run_parameters(leader_tracker: LeaderTracker) -> ClientCliParameters {
@@ -336,7 +339,7 @@ mod tests {
                     initial_congestion_window: None,
                     drain_seconds: 0,
                     num_max_open_connections: 1,
-                    workers_pull_size: 1,
+                    workers_pull_size: NonZeroUsize::new(1).unwrap(),
                     send_fanout: 1,
                     compute_unit_price: None,
                     priority_fee_params: PriorityFeeParams {
@@ -350,7 +353,7 @@ mod tests {
                         max_lamports_to_transfer: 513,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
-                        tx_batch_size: None,
+                        tx_batch_size: NonZeroUsize::new(64).unwrap(),
                         num_conflict_groups: None,
                     },
                     padding_params: InstructionPaddingParams {

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -3,19 +3,13 @@ use {
         backpressured_broadcaster::BackpressuredBroadcaster,
         cli::{EndpointConfig, ExecutionParams, TransactionParams},
         error::BenchClientError,
-        generator::TransactionGenerator,
+        generator::{TransactionGenerator, transaction_generator::check_num_conflict_groups},
         priority_fee::{PriorityFeeMode, PriorityFeeStats},
     },
     log::*,
     solana_keypair::Keypair,
-    solana_pubkey::Pubkey,
-    solana_quic_definitions::{
-        QUIC_MAX_STAKED_CONCURRENT_STREAMS, QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
-        QUIC_MIN_STAKED_CONCURRENT_STREAMS, QUIC_TOTAL_STAKED_CONCURRENT_STREAMS,
-    },
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
-    solana_signer::{EncodableKey, Signer},
-    solana_streamer::nonblocking::quic::ConnectionPeerType,
+    solana_signer::EncodableKey,
     solana_tpu_client_next::{
         ConnectionWorkersScheduler, SendTransactionStats, WireTransaction,
         connection_workers_scheduler::{
@@ -49,61 +43,12 @@ const WORKER_CHANNEL_SIZE: usize = 20;
 /// doesn't affect TPS.
 const MAX_RECONNECT_ATTEMPTS: usize = 5;
 
-/// Default number of streams per connection if stake-based computation fails.
-/// This failure happens if we use stake overrides.
-const DEFAULT_NUM_STREAMS_PER_CONNECTION: usize = 8;
-const TARGET_BATCHES_PER_SECOND: u64 = 10;
-
 pub struct RunClientStats {
     pub send_transaction_stats: Vec<Arc<SendTransactionStats>>,
     pub priority_fee_stats: Arc<PriorityFeeStats>,
 }
 
 pub type RunClientStatsSender = oneshot::Sender<RunClientStats>;
-
-async fn find_node_activated_stake(
-    rpc_client: &Arc<RpcClient>,
-    node_id: Option<Pubkey>,
-) -> Result<(Option<u64>, u64), BenchClientError> {
-    let vote_accounts = rpc_client
-        .get_vote_accounts()
-        .await
-        .map_err(|_| BenchClientError::FindValidatorIdentityFailure)?;
-
-    let total_active_stake: u64 = vote_accounts
-        .current
-        .iter()
-        .map(|vote_account| vote_account.activated_stake)
-        .sum();
-
-    let Some(node_id) = node_id else {
-        return Ok((None, total_active_stake));
-    };
-    let node_id_as_str = node_id.to_string();
-    let find_result = vote_accounts
-        .current
-        .iter()
-        .find(|&vote_account| vote_account.node_pubkey == node_id_as_str);
-    match find_result {
-        Some(value) => Ok((Some(value.activated_stake), total_active_stake)),
-        None => Err(BenchClientError::FindValidatorIdentityFailure),
-    }
-}
-
-async fn compute_num_streams(
-    rpc_client: &Arc<RpcClient>,
-    validator_pubkey: Option<Pubkey>,
-) -> Result<usize, BenchClientError> {
-    let (validator_stake, total_stake) =
-        find_node_activated_stake(rpc_client, validator_pubkey).await?;
-    debug!(
-        "Validator {validator_pubkey:?} stake: {validator_stake:?}, total stake: {total_stake}."
-    );
-    let client_type = validator_stake.map_or(ConnectionPeerType::Unstaked, |stake| {
-        ConnectionPeerType::Staked(stake)
-    });
-    Ok(compute_max_allowed_uni_streams(client_type, total_stake))
-}
 
 async fn join_service<Error>(
     handle: JoinHandle<Result<(), Error>>,
@@ -148,95 +93,52 @@ pub async fn run_client(
         .map(load_identity)
         .collect::<Result<Vec<_>, _>>()?;
 
-    // Set up size of the txs batch to put into the queue to be equal to the minimum
-    // stream count across configured endpoints.
-    let mut num_streams_per_connection = usize::MAX;
-    for (endpoint_config, validator_identity) in
-        endpoint_configs.iter().zip(endpoint_identities.iter())
-    {
-        let endpoint_num_streams = compute_num_streams(
-            &rpc_client,
-            validator_identity.as_ref().map(|keypair| keypair.pubkey()),
-        )
-        .await
-        .unwrap_or(DEFAULT_NUM_STREAMS_PER_CONNECTION);
-        info!(
-            "Endpoint {} will use {endpoint_num_streams} streams per connection.",
-            endpoint_config.bind
-        );
-        num_streams_per_connection = num_streams_per_connection.min(endpoint_num_streams);
-    }
-    if num_streams_per_connection == usize::MAX {
-        num_streams_per_connection = DEFAULT_NUM_STREAMS_PER_CONNECTION;
-    }
-
-    let tx_batch_size = transaction_params
+    let generate_tx_batch_size = transaction_params
         .simple_transfer_tx_params
         .tx_batch_size
-        .map(|n| n.get());
-    let send_batch_size = compute_send_batch_size(
-        tx_batch_size,
-        num_streams_per_connection,
-        execution_params.target_tps,
-    );
-    let workers_pull_size = compute_workers_pull_size(
-        execution_params.workers_pull_size,
-        send_batch_size,
-        execution_params.target_tps,
-    );
-    info!("Number of streams per connection is {num_streams_per_connection}.");
-    if let Some(tx_batch_size) = tx_batch_size {
-        info!("Using tx batch size override: {tx_batch_size}.");
-    } else if let Some(target_tps) = execution_params.target_tps {
-        info!("Using rate-limited tx batch size {send_batch_size} for target {target_tps} tx/s.");
-    }
-    if let Some(target_tps) = execution_params.target_tps {
+        .get();
+    let workers_pull_size = execution_params.workers_pull_size.get();
+    let num_transactions = execution_params.num_transactions.map(NonZeroU64::get);
+    let target_tps = execution_params.target_tps.map(NonZeroU64::get);
+    if let Some(target_tps) = target_tps {
         info!("Using {workers_pull_size} generator workers for target {target_tps} tx/s.");
     }
 
     {
-        let transfer_instructions_per_batch = transaction_params
+        let transfer_instructions_per_tx = transaction_params
             .simple_transfer_tx_params
-            .num_send_instructions_per_tx
-            .saturating_mul(send_batch_size);
-        if transfer_instructions_per_batch
-            > transaction_params
+            .num_send_instructions_per_tx;
+        let transfer_instructions_per_batch =
+            transfer_instructions_per_tx.saturating_mul(generate_tx_batch_size);
+        let max_lamports_to_transfer = usize::try_from(
+            transaction_params
                 .simple_transfer_tx_params
-                .max_lamports_to_transfer as usize
-        {
+                .max_lamports_to_transfer,
+        )
+        .unwrap_or(usize::MAX);
+        if transfer_instructions_per_batch > max_lamports_to_transfer {
             return Err(BenchClientError::InvalidCliArguments(format!(
                 "--max-lamports-to-transfer ({}) must be >= transfer instructions per generated \
-                 batch ({}) ; computed as num-send-instructions-per-tx ({}) * tx-batch-size ({})",
+                 batch ({}) computed as num-send-instructions-per-tx ({}) * tx-batch-size ({})",
                 transaction_params
                     .simple_transfer_tx_params
                     .max_lamports_to_transfer,
                 transfer_instructions_per_batch,
-                transaction_params
-                    .simple_transfer_tx_params
-                    .num_send_instructions_per_tx,
-                send_batch_size
+                transfer_instructions_per_tx,
+                generate_tx_batch_size
             )));
         }
     }
 
-    if let Some(num_conflict_groups) = transaction_params
-        .simple_transfer_tx_params
-        .num_conflict_groups
-    {
-        let num_send_instructions_per_tx = transaction_params
+    check_num_conflict_groups(
+        transaction_params
             .simple_transfer_tx_params
-            .num_send_instructions_per_tx;
-        let max_groups = num_send_instructions_per_tx.saturating_mul(send_batch_size);
-        let num_conflict_groups = num_conflict_groups.get();
-
-        if num_conflict_groups > max_groups {
-            return Err(BenchClientError::InvalidCliArguments(format!(
-                "--num-conflict-groups ({num_conflict_groups}) must be <= \
-                 num-send-instructions-per-tx ({num_send_instructions_per_tx}) * tx-batch-size \
-                 ({send_batch_size})"
-            )));
-        }
-    }
+            .num_conflict_groups,
+        transaction_params
+            .simple_transfer_tx_params
+            .num_send_instructions_per_tx,
+        generate_tx_batch_size,
+    )?;
 
     if let Some(instruction_padding_config) = transaction_params.instruction_padding_config() {
         info!(
@@ -289,10 +191,10 @@ pub async fn run_client(
         execution_params.compute_unit_price,
         priority_fee_mode,
         priority_fee_stats.clone(),
-        send_batch_size,
         execution_params.duration,
-        execution_params.num_transactions,
-        execution_params.target_tps,
+        num_transactions,
+        target_tps,
+        generate_tx_batch_size,
         workers_pull_size,
     );
 
@@ -430,69 +332,4 @@ async fn build_schedulers(
     }
 
     Ok((scheduler_handles, all_stats))
-}
-
-#[allow(clippy::arithmetic_side_effects)]
-fn compute_send_batch_size(
-    tx_batch_size_override: Option<usize>,
-    num_streams_per_connection: usize,
-    target_tps: Option<NonZeroU64>,
-) -> usize {
-    tx_batch_size_override.unwrap_or_else(|| {
-        target_tps.map_or(num_streams_per_connection, |target_tps| {
-            let target_tps = target_tps.get();
-            let target_batch_size = target_tps.div_ceil(TARGET_BATCHES_PER_SECOND);
-            usize::try_from(target_batch_size)
-                .unwrap_or(usize::MAX)
-                .clamp(1, num_streams_per_connection)
-        })
-    })
-}
-
-#[allow(clippy::arithmetic_side_effects)]
-fn compute_workers_pull_size(
-    configured_workers_pull_size: usize,
-    send_batch_size: usize,
-    target_tps: Option<NonZeroU64>,
-) -> usize {
-    target_tps.map_or(configured_workers_pull_size, |target_tps| {
-        let target_batches_per_sec = target_tps
-            .get()
-            .div_ceil(u64::try_from(send_batch_size).unwrap_or(u64::MAX));
-        let guessed_workers = match target_batches_per_sec {
-            0..=1 => 1,
-            2..=10 => 2,
-            _ => 4,
-        };
-        guessed_workers.min(configured_workers_pull_size.max(1))
-    })
-}
-
-// Private function copied from streamer::nonblocking::swqos
-#[allow(clippy::arithmetic_side_effects)]
-fn compute_max_allowed_uni_streams(peer_type: ConnectionPeerType, total_stake: u64) -> usize {
-    match peer_type {
-        ConnectionPeerType::Staked(peer_stake) => {
-            // No checked math for f64 type. So let's explicitly check for 0 here
-            if total_stake == 0 || peer_stake > total_stake {
-                warn!(
-                    "Invalid stake values: peer_stake: {peer_stake:?}, total_stake: \
-                     {total_stake:?}"
-                );
-
-                QUIC_MIN_STAKED_CONCURRENT_STREAMS
-            } else {
-                let delta = (QUIC_TOTAL_STAKED_CONCURRENT_STREAMS
-                    - QUIC_MIN_STAKED_CONCURRENT_STREAMS) as f64;
-
-                (((peer_stake as f64 / total_stake as f64) * delta) as usize
-                    + QUIC_MIN_STAKED_CONCURRENT_STREAMS)
-                    .clamp(
-                        QUIC_MIN_STAKED_CONCURRENT_STREAMS,
-                        QUIC_MAX_STAKED_CONCURRENT_STREAMS,
-                    )
-            }
-        }
-        ConnectionPeerType::Unstaked => QUIC_MAX_UNSTAKED_CONCURRENT_STREAMS,
-    }
 }

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -33,7 +33,7 @@ use {
     },
     std::{
         net::{IpAddr, Ipv4Addr, SocketAddr},
-        num::NonZeroU64,
+        num::{NonZeroU64, NonZeroUsize},
         sync::Arc,
         time::{Duration, Instant},
     },
@@ -127,7 +127,7 @@ fn test_transactions_sending() {
                     max_lamports_to_transfer: 513,
                     transfer_tx_cu_budget: 600,
                     num_send_instructions_per_tx: 1,
-                    tx_batch_size: None,
+                    tx_batch_size: NonZeroUsize::new(64).unwrap(),
                     num_conflict_groups: None,
                 },
                 padding_params: InstructionPaddingParams {
@@ -146,7 +146,7 @@ fn test_transactions_sending() {
                 initial_congestion_window: None,
                 drain_seconds: 0,
                 num_max_open_connections: 1,
-                workers_pull_size: 1,
+                workers_pull_size: NonZeroUsize::new(1).unwrap(),
                 send_fanout: 1,
                 compute_unit_price: Some(100),
                 priority_fee_params: PriorityFeeParams {


### PR DESCRIPTION
Due to updates of SWQoS it makes no sense to define transaction batches based on the stake size. Beside of that we also use now tpu-client-next which is sending individual transactions instead of batches.
This PR simplifies code by removing aforementioned unnecessary batching. It also removes dependency on the deprecated crate `solana-quic-definitions` which is not used in agave anylonger.
But it leaves batching for transaction generation because it makes sense performance-wise to generate at least 64 txs together. 

This is on top of the other PR. So wait until previous PR is merged