### PR TITLE
replace bincode with wincode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9611,7 +9611,6 @@ version = "0.1.0"
 dependencies = [
  "async-stream",
  "async-trait",
- "bincode",
  "chrono",
  "clap 4.6.5",
  "futures 0.3.33",
@@ -9642,6 +9641,7 @@ dependencies = [
  "tokio",
  "tokio-util 0.7.19",
  "tonic",
+ "wincode",
  "yellowstone-grpc-client",
  "yellowstone-grpc-proto",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ agave-logger = { version = "=4.3.0-beta.0", features = ["agave-unstable-api"] }
 async-std = "1.12.0"
 async-stream = "0.3.6"
 async-trait = "0.1.91"
-bincode = "1.3.3"
 chrono = { version = "0.4.45", default-features = false }
 clap = { package = "clap", version = "4.6.1" }
 crossbeam-channel = "0.5.16"
@@ -73,7 +72,7 @@ solana-sha256-hasher = "=3.1.0"
 solana-signature = { version = "3.5.1", default-features = false }
 solana-signer = "=3.0.1"
 solana-streamer = { version = "=4.3.0-beta.0", features = ["agave-unstable-api"] }
-solana-system-interface = { version = "3.3.0", features = ["alloc", "bincode", "serde", "wincode"] }
+solana-system-interface = { version = "3.3.0", features = ["alloc", "wincode"] }
 solana-test-validator = { version = "=4.3.0-beta.0", features = ["agave-unstable-api"] }
 solana-time-utils = "=3.0.0"
 solana-tpu-client = { version = "=4.3.0-beta.0", default-features = false, features = ["agave-unstable-api"] }

--- a/tpu-tools-common/Cargo.toml
+++ b/tpu-tools-common/Cargo.toml
@@ -54,10 +54,9 @@ yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 
 [dev-dependencies]
-# Using bincode since serializing txns isn't compatible with wincode
-bincode = { workspace = true }
 rand = { workspace = true }
 solana-sha256-hasher = { workspace = true }
+wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/tpu-tools-common/src/accounts_creator.rs
+++ b/tpu-tools-common/src/accounts_creator.rs
@@ -498,13 +498,13 @@ mod tests {
             "expected at least one transaction in the generated batch"
         );
 
-        // Legacy packets are capped at 1232 bytes; `Transaction` uses solana-transaction 3.x with
-        // bincode/serde — `serialized_size` bounds the wire size for these `VersionedTransaction` values.
+        // Legacy packets are capped at 1232 bytes; `serialized_size` bounds the wire size for
+        // these `VersionedTransaction` values.
         const SOLANA_TXN_MAX_BYTES: usize = 1232;
 
         for (i, (tx, _new_accounts)) in txn.iter().enumerate() {
-            let txn_size = bincode::serialized_size(tx)
-                .expect("transaction should be bincode-serializable")
+            let txn_size = wincode::serialized_size(tx)
+                .expect("transaction should be wincode-serializable")
                 as usize;
             assert!(
                 txn_size <= SOLANA_TXN_MAX_BYTES,

--- a/tpu-tools-common/src/accounts_deleter.rs
+++ b/tpu-tools-common/src/accounts_deleter.rs
@@ -274,8 +274,8 @@ mod tests {
         assert_eq!(txs.len(), 1);
 
         const SOLANA_TXN_MAX_BYTES: usize = 1232;
-        let txn_size = bincode::serialized_size(&txs[0].0)
-            .expect("transaction should be bincode-serializable") as usize;
+        let txn_size = wincode::serialized_size(&txs[0].0)
+            .expect("transaction should be wincode-serializable") as usize;
         assert!(
             txn_size <= SOLANA_TXN_MAX_BYTES,
             "serialized transaction size {txn_size} exceeds Solana limit {SOLANA_TXN_MAX_BYTES}"


### PR DESCRIPTION
bincode is deprecated in upstream agave. Hence, deprecate it also here.