### PR TITLE
fix: compare payer balances in lamports during account validation

### DIFF
--- a/tpu-tools-common/src/accounts_file.rs
+++ b/tpu-tools-common/src/accounts_file.rs
@@ -7,7 +7,6 @@ use {
     log::error,
     serde::{Deserialize, Serialize},
     solana_keypair::Keypair,
-    solana_native_token::LAMPORTS_PER_SOL,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::client_error::Error as RpcClientError,
     solana_signer::Signer,
@@ -163,11 +162,11 @@ async fn validate_payers(
         return Ok(false);
     }
     for payer in payers {
-        let balance_sol: u64 = rpc_client.get_balance(&payer.pubkey()).await?;
-        if balance_sol.saturating_mul(LAMPORTS_PER_SOL) < desired_balance_lamports {
+        let balance_lamports: u64 = rpc_client.get_balance(&payer.pubkey()).await?;
+        if balance_lamports < desired_balance_lamports {
             error!(
-                "Insufficient balance {}SOL for account {}.",
-                balance_sol,
+                "Insufficient balance {} lamports for account {}.",
+                balance_lamports,
                 payer.pubkey()
             );
             return Ok(false);
@@ -252,6 +251,29 @@ mod tests {
             AccountsFile {
                 payers: vec![keypair.insecure_clone(), keypair.insecure_clone()],
             }
+        );
+    }
+
+    #[tokio::test]
+    async fn test_validate_payers_checks_lamports_balance() {
+        let rpc_client = Arc::new(RpcClient::new_mock("succeeds".to_string()));
+        let accounts = AccountsFile {
+            payers: vec![Keypair::new()],
+        };
+
+        // Mock RPC returns a balance of 50 lamports. A desired balance above the
+        // actual must fail validation; equal to it must pass.
+        assert!(
+            !validate_payers(&accounts, rpc_client.clone(), 1, 100)
+                .await
+                .unwrap(),
+            "payer with 50 lamports must fail a 100 lamports balance check"
+        );
+        assert!(
+            validate_payers(&accounts, rpc_client.clone(), 1, 50)
+                .await
+                .unwrap(),
+            "payer with 50 lamports must pass a 50 lamports balance check"
         );
     }
 


### PR DESCRIPTION
## What

`validate_payers` compared the payer's actual on-chain balance against the desired balance with the wrong units. `rpc_client.get_balance()` already returns lamports, but the code multiplied the result by `LAMPORTS_PER_SOL` (1e9), inflating the effective threshold by a factor of 1e9.

## Why

With `--validate-accounts`, a payer holding almost any nonzero balance (e.g. 1 lamport with `--payer-account-balance 1SOL`) evaluated as sufficiently funded: `1 * 1e9 = 1e9 >= 1e9`. The check only failed for accounts with exactly 0 lamports, so the tool silently ran with underfunded payers whose transactions were all dropped with `InsufficientFunds`. The error log also printed lamports mislabeled as `{}SOL`.

## Change

- Compare `balance_lamports < desired_balance_lamports` directly.
- Log the balance in lamports instead of as a mislabeled SOL value.
- Add a regression test `test_validate_payers_checks_lamports_balance` that fails on the old code (mock RPC returns 50 lamports; a 100-lamports desired balance must be rejected) and passes on the fix.