### PR TITLE
fix transaction generator hanging

### DIFF
--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -19,6 +19,7 @@ use {
         task::JoinSet,
         time::{Duration, Instant},
     },
+    tokio_util::sync::CancellationToken,
 };
 
 const COMPUTE_BUDGET_INSTRUCTION_CU_COST: u32 = 150;
@@ -47,6 +48,7 @@ pub struct TransactionGenerator {
     target_tps: Option<u64>,
     generate_tx_batch_size: usize,
     workers_pull_size: usize,
+    cancel: CancellationToken,
 }
 
 impl TransactionGenerator {
@@ -64,6 +66,7 @@ impl TransactionGenerator {
         target_tps: Option<u64>,
         generate_tx_batch_size: usize,
         workers_pull_size: usize,
+        cancel: CancellationToken,
     ) -> Self {
         Self {
             accounts,
@@ -78,6 +81,7 @@ impl TransactionGenerator {
             target_tps,
             generate_tx_batch_size,
             workers_pull_size,
+            cancel,
         }
     }
 
@@ -128,6 +132,7 @@ impl TransactionGenerator {
                 txs_scheduled,
             ) {
                 info!("Transaction generator is stopping: {stop_reason}.");
+                self.cancel.cancel();
                 while let Some(result) = futures.join_next().await {
                     debug!("Future result {result:?}");
                 }
@@ -174,6 +179,7 @@ impl TransactionGenerator {
                             &mut lamports_index,
                             total_pairs,
                         );
+                        let cancel = self.cancel.clone();
                         futures.spawn(async move {
                             let Ok(wired_tx_batch) = generate_transfer_transaction_batch(
                                 payers,
@@ -192,7 +198,13 @@ impl TransactionGenerator {
                                 return;
                             };
 
-                            send_batch(wired_tx_batch, transactions_sender).await;
+                            tokio::select! {
+                                _ = send_batch(wired_tx_batch, transactions_sender) => {}
+                                _ = cancel.cancelled()  => {}
+                                _ = tokio::time::sleep(Duration::from_secs(5)) => {
+                                    debug!("Timed out sending generated txs to the channel.");
+                                }
+                            }
                         });
 
                         let receivers_consumed =

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -25,6 +25,7 @@ use {
 const COMPUTE_BUDGET_INSTRUCTION_CU_COST: u32 = 150;
 const SIMPLE_TRANSFER_INSTRUCTION_CU_COST: u32 = 150;
 const PADDED_TRANSFER_INSTRUCTION_CU_COST: u32 = 3_000;
+const SEND_BATCH_SAFETY_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Error, Debug)]
 pub enum TransactionGeneratorError {
@@ -124,6 +125,7 @@ impl TransactionGenerator {
         let start = Instant::now();
         let mut next_batch_at = self.target_tps.map(|_| start);
         let mut txs_scheduled: u64 = 0;
+        let run_deadline = self.run_duration.map(|duration| start + duration);
         loop {
             if let Some(stop_reason) = stop_reason(
                 self.run_duration,
@@ -198,11 +200,18 @@ impl TransactionGenerator {
                                 return;
                             };
 
+                            let send_batch_timeout = run_deadline
+                                .map(|deadline| deadline.saturating_duration_since(Instant::now()))
+                                .unwrap_or(SEND_BATCH_SAFETY_TIMEOUT);
                             tokio::select! {
                                 _ = send_batch(wired_tx_batch, transactions_sender) => {}
                                 _ = cancel.cancelled()  => {}
-                                _ = tokio::time::sleep(Duration::from_secs(5)) => {
-                                    debug!("Timed out sending generated txs to the channel.");
+                                _ = tokio::time::sleep(send_batch_timeout) => {
+                                    warn!(
+                                        "Timed out sending generated txs to the channel after \
+                                         {send_batch_timeout:?}. Probably, something is off with \
+                                         connections and client cannot make progress."
+                                    );
                                 }
                             }
                         });

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -207,7 +207,7 @@ impl TransactionGenerator {
                                 _ = send_batch(wired_tx_batch, transactions_sender) => {}
                                 _ = cancel.cancelled()  => {}
                                 _ = tokio::time::sleep(send_batch_timeout) => {
-                                    warn!(
+                                    info!(
                                         "Timed out sending generated txs to the channel after \
                                          {send_batch_timeout:?}. Probably, something is off with \
                                          connections and client cannot make progress."

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -196,6 +196,7 @@ pub async fn run_client(
         target_tps,
         generate_tx_batch_size,
         workers_pull_size,
+        cancel.child_token(),
     );
 
     let leader_updater_config = LeaderTpuCacheServiceConfig {

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -31,8 +31,6 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-const GENERATOR_CHANNEL_SIZE: usize = 32;
-
 /// Empirically chosen size of the connection worker channel. Lower/higher values gives
 /// significantly smaller txs blocks on testnet.
 const WORKER_CHANNEL_SIZE: usize = 20;
@@ -94,6 +92,14 @@ pub async fn run_client(
         .simple_transfer_tx_params
         .tx_batch_size
         .get();
+    let generator_channel_size = workers_pull_size
+        .checked_mul(generate_tx_batch_size)
+        .ok_or_else(|| {
+            BenchClientError::InvalidCliArguments(format!(
+                "--workers-pull-size ({workers_pull_size}) * --tx-batch-size \
+                 ({generate_tx_batch_size}) overflows usize"
+            ))
+        })?;
     if let Some(target_tps) = target_tps {
         info!("Using {workers_pull_size} generator workers for target {target_tps} tx/s.");
     }
@@ -167,7 +173,7 @@ pub async fn run_client(
     let mut transaction_senders = Vec::with_capacity(num_endpoints);
     let mut transaction_receivers = Vec::with_capacity(num_endpoints);
     for _ in 0..num_endpoints {
-        let (sender, receiver) = mpsc::channel(GENERATOR_CHANNEL_SIZE);
+        let (sender, receiver) = mpsc::channel(generator_channel_size);
         transaction_senders.push(sender);
         transaction_receivers.push(receiver);
     }

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -92,14 +92,7 @@ pub async fn run_client(
         .simple_transfer_tx_params
         .tx_batch_size
         .get();
-    let generator_channel_size = workers_pull_size
-        .checked_mul(generate_tx_batch_size)
-        .ok_or_else(|| {
-            BenchClientError::InvalidCliArguments(format!(
-                "--workers-pull-size ({workers_pull_size}) * --tx-batch-size \
-                 ({generate_tx_batch_size}) overflows usize"
-            ))
-        })?;
+    let generator_channel_size = workers_pull_size.saturating_mul(generate_tx_batch_size);
     if let Some(target_tps) = target_tps {
         info!("Using {workers_pull_size} generator workers for target {target_tps} tx/s.");
     }


### PR DESCRIPTION
To be reviewed by commit.

It might happen that transaction-generator hangs:
* the deadline for duration or num-txs is checked at the begging of the generator loop
* the loop can stop waiting for join_next
* if channel is full, workers will try to send for indefinitely long 

It might happen if, for example, pinned validator is broken and cannot accept transactions over quinn. So we will try sending to it, saturate tpu-client-next channel and there is no consumption of generated txs. Generator will wait to add some more transactions never returning to the begging of the loop.

