### PR TITLE
Use TPU for account creation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9385,6 +9385,7 @@ dependencies = [
  "solana-keypair",
  "solana-leader-schedule",
  "solana-native-token",
+ "solana-net-utils",
  "solana-pubkey 4.3.0",
  "solana-rpc-client",
  "solana-rpc-client-api",

--- a/rate-latency-tool/src/main.rs
+++ b/rate-latency-tool/src/main.rs
@@ -11,10 +11,15 @@ use {
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::{EncodableKey, Signer},
     solana_tpu_client_next::SendTransactionStats,
-    solana_tpu_tools_common::accounts_file::{
-        create_ephemeral_accounts, create_file_persisted_accounts, read_accounts_file,
+    solana_tpu_tools_common::{
+        accounts_creator::create_tpu_account_creation_client,
+        accounts_file::{
+            create_ephemeral_accounts_with_sender, create_file_persisted_accounts_with_sender,
+            read_accounts_file,
+        },
+        cli::LeaderTracker,
     },
-    std::{sync::Arc, time::Duration},
+    std::{num::NonZeroUsize, sync::Arc, time::Duration},
     tokio_util::sync::CancellationToken,
 };
 
@@ -62,14 +67,29 @@ async fn run(parameters: ClientCliParameters) -> Result<(), RateLatencyToolError
             execution_params,
             analysis_params,
         } => {
-            let accounts = create_ephemeral_accounts(
+            let account_creation_client = create_tpu_account_creation_client(
+                rpc_client.clone(),
+                execution_params.leader_tracker.clone(),
+                websocket_url.clone(),
+                execution_params.bind,
+                execution_params.staked_identity_file.clone(),
+                NonZeroUsize::new(execution_params.num_max_open_connections)
+                    .expect("num-max-open-connections must be non-zero"),
+                execution_params.send_fanout,
+                cancel.child_token(),
+            )
+            .await?;
+            let accounts = create_ephemeral_accounts_with_sender(
                 rpc_client.clone(),
                 authority,
                 account_params.num_payers,
                 account_params.payer_account_balance,
                 parameters.validate_accounts,
+                account_creation_client.transaction_sender.clone(),
             )
-            .await?;
+            .await;
+            account_creation_client.shutdown().await?;
+            let accounts = accounts?;
             let stats = Arc::new(SendTransactionStats::default());
             let metrics_task = spawn_metrics_reporter(stats.clone(), cancel.clone());
             let result = run_client(
@@ -105,15 +125,31 @@ async fn run(parameters: ClientCliParameters) -> Result<(), RateLatencyToolError
             finish_client_run(result, cancel, metrics_task).await?;
         }
         Command::WriteAccounts(write_accounts) => {
-            create_file_persisted_accounts(
+            let account_creation_client = create_tpu_account_creation_client(
+                rpc_client.clone(),
+                LeaderTracker::WsLeaderTracker,
+                websocket_url,
+                "0.0.0.0:0"
+                    .parse()
+                    .expect("default bind address should be valid"),
+                None,
+                NonZeroUsize::new(16).expect("default max open connections must be non-zero"),
+                1,
+                cancel.child_token(),
+            )
+            .await?;
+            let result = create_file_persisted_accounts_with_sender(
                 rpc_client.clone(),
                 authority,
                 write_accounts.accounts_file,
                 write_accounts.account_params.num_payers,
                 write_accounts.account_params.payer_account_balance,
                 parameters.validate_accounts,
+                account_creation_client.transaction_sender.clone(),
             )
-            .await?;
+            .await;
+            account_creation_client.shutdown().await?;
+            result?;
         }
     }
 

--- a/tpu-tools-common/Cargo.toml
+++ b/tpu-tools-common/Cargo.toml
@@ -33,6 +33,7 @@ solana-instruction = { workspace = true }
 solana-keypair = { workspace = true }
 solana-leader-schedule = { workspace = true }
 solana-native-token = { workspace = true }
+solana-net-utils = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-rpc-client = { workspace = true }
 solana-rpc-client-api = { workspace = true }
@@ -48,13 +49,13 @@ thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tonic = { workspace = true }
+wincode = { workspace = true }
 yellowstone-grpc-client = { workspace = true }
 yellowstone-grpc-proto = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }
 solana-sha256-hasher = { workspace = true }
-wincode = { workspace = true }
 
 [lints]
 workspace = true

--- a/tpu-tools-common/src/accounts_creator.rs
+++ b/tpu-tools-common/src/accounts_creator.rs
@@ -1,4 +1,4 @@
-//! RPC-backed payer account creation for TPU tools.
+//! Payer account creation for TPU tools.
 //!
 //! This module creates funded payer accounts that transaction generators can
 //! rotate through to avoid introducing unnecessary account contention.
@@ -7,6 +7,8 @@ use {
     crate::{
         accounts_file::{AccountsFile, write_accounts_file},
         blockhash_updater::BlockhashUpdater,
+        cli::LeaderTracker,
+        leader_updater::{LeaderUpdaterFactory, create_leader_updater},
     },
     chrono::prelude::Utc,
     futures::future::join_all,
@@ -14,6 +16,7 @@ use {
     solana_commitment_config::CommitmentConfig,
     solana_hash::Hash,
     solana_keypair::Keypair,
+    solana_net_utils::sockets::bind_to,
     solana_pubkey::Pubkey,
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_rpc_client_api::{
@@ -21,9 +24,13 @@ use {
         response::transaction::{Transaction, versioned::VersionedTransaction},
     },
     solana_sdk_ids::system_program,
-    solana_signer::Signer,
+    solana_signer::{EncodableKey, Signer},
     solana_system_interface::instruction as system_instruction,
-    std::{path::PathBuf, sync::Arc},
+    solana_tpu_client_next::{
+        Client, ClientBuilder, ClientError as TpuClientError, TransactionSender,
+        client_builder::ClientBuilderError, node_address_service::LeaderTpuCacheServiceConfig,
+    },
+    std::{net::SocketAddr, num::NonZeroUsize, path::PathBuf, sync::Arc},
     thiserror::Error,
     tokio::{
         sync::watch,
@@ -55,9 +62,92 @@ pub enum Error {
     /// Account creation did not produce the requested number of payer accounts.
     #[error("Failed to create account")]
     CreateAccountFailure,
+
+    /// TPU client could not be built.
+    #[error(transparent)]
+    TpuClientBuilderError(#[from] ClientBuilderError),
+
+    /// TPU client request failed.
+    #[error(transparent)]
+    TpuClientError(#[from] TpuClientError),
+
+    /// Leader updater creation failed.
+    #[error(transparent)]
+    LeaderUpdaterError(#[from] crate::leader_updater::Error),
+
+    /// UDP bind failed.
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
+
+    /// A keypair file could not be read.
+    #[error("Failed to read keypair file")]
+    KeypairReadFailure,
 }
 
-/// Creates funded payer accounts through a Solana RPC endpoint.
+/// Transport used to submit account-creation transactions.
+#[derive(Clone)]
+pub enum AccountCreationSender {
+    /// Submit and confirm transactions through RPC.
+    Rpc,
+    /// Submit transactions through TPU and confirm them through RPC.
+    Tpu(TransactionSender),
+}
+
+/// TPU client used while creating accounts.
+pub struct TpuAccountCreationClient {
+    pub transaction_sender: AccountCreationSender,
+    client: Client,
+    leader_service: LeaderUpdaterFactory,
+}
+
+impl TpuAccountCreationClient {
+    pub async fn shutdown(self) -> Result<(), Error> {
+        let client_result = self.client.shutdown().await;
+        let service_result = self.leader_service.shutdown().await;
+        client_result?;
+        service_result?;
+        Ok(())
+    }
+}
+
+pub async fn create_tpu_account_creation_client(
+    rpc_client: Arc<RpcClient>,
+    leader_tracker: LeaderTracker,
+    websocket_url: String,
+    bind: SocketAddr,
+    stake_identity_file: Option<PathBuf>,
+    num_max_open_connections: NonZeroUsize,
+    send_fanout: usize,
+    cancel: tokio_util::sync::CancellationToken,
+) -> Result<TpuAccountCreationClient, Error> {
+    let stake_identity = stake_identity_file
+        .map(|path| Keypair::read_from_file(path).map_err(|_| Error::KeypairReadFailure))
+        .transpose()?;
+    let leader_service = create_leader_updater(
+        rpc_client,
+        leader_tracker,
+        LeaderTpuCacheServiceConfig::default(),
+        websocket_url,
+        cancel.clone(),
+    )
+    .await?;
+    let leader_updater = leader_service.create_updater().await?;
+    let bind_socket = bind_to(bind.ip(), bind.port())?;
+    let (transaction_sender, client) = ClientBuilder::new(leader_updater)
+        .bind_socket(bind_socket)
+        .identity(stake_identity.as_ref())
+        .max_cache_size(num_max_open_connections)
+        .leader_send_fanout(send_fanout)
+        .cancel_token(cancel)
+        .build()?;
+
+    Ok(TpuAccountCreationClient {
+        transaction_sender: AccountCreationSender::Tpu(transaction_sender),
+        client,
+        leader_service,
+    })
+}
+/// Creates funded payer accounts.
 ///
 /// The creator checks that the authority has enough lamports to fund the
 /// requested accounts, requests an airdrop when needed, then sends batched
@@ -67,6 +157,7 @@ pub struct AccountsCreator {
     authority: Keypair,
     num_payers: usize,
     payer_account_balance_lamports: u64,
+    transaction_sender: AccountCreationSender,
 }
 
 impl AccountsCreator {
@@ -85,6 +176,24 @@ impl AccountsCreator {
             authority,
             num_payers,
             payer_account_balance_lamports,
+            transaction_sender: AccountCreationSender::Rpc,
+        }
+    }
+
+    /// Creates a new account creator using an explicit transaction sender.
+    pub fn new_with_transaction_sender(
+        rpc_client: Arc<RpcClient>,
+        authority: Keypair,
+        num_payers: usize,
+        payer_account_balance_lamports: u64,
+        transaction_sender: AccountCreationSender,
+    ) -> Self {
+        Self {
+            rpc_client,
+            authority,
+            num_payers,
+            payer_account_balance_lamports,
+            transaction_sender,
         }
     }
 
@@ -181,6 +290,7 @@ impl AccountsCreator {
             self.num_payers,
             self.payer_account_balance_lamports,
             MAX_CONTINUOUS_FAILED_ATTEMPTS,
+            &self.transaction_sender,
         )
         .await
     }
@@ -257,6 +367,21 @@ fn create_transaction_batch(
 async fn send_transaction_batch(
     rpc_client: &Arc<RpcClient>,
     transaction_batch: Vec<(VersionedTransaction, Vec<Keypair>)>,
+    transaction_sender: &AccountCreationSender,
+) -> Vec<Keypair> {
+    match transaction_sender {
+        AccountCreationSender::Rpc => {
+            send_transaction_batch_by_rpc(rpc_client, transaction_batch).await
+        }
+        AccountCreationSender::Tpu(transaction_sender) => {
+            send_transaction_batch_by_tpu(rpc_client, transaction_sender, transaction_batch).await
+        }
+    }
+}
+
+async fn send_transaction_batch_by_rpc(
+    rpc_client: &Arc<RpcClient>,
+    transaction_batch: Vec<(VersionedTransaction, Vec<Keypair>)>,
 ) -> Vec<Keypair> {
     // send txs concurrently to RPC with confirmation
     let futures = transaction_batch
@@ -271,6 +396,46 @@ async fn send_transaction_batch(
     results
         .into_iter()
         .filter_map(|(result, account_keypairs)| result.ok().map(|_| account_keypairs))
+        .flatten()
+        .collect()
+}
+
+async fn send_transaction_batch_by_tpu(
+    rpc_client: &Arc<RpcClient>,
+    transaction_sender: &TransactionSender,
+    transaction_batch: Vec<(VersionedTransaction, Vec<Keypair>)>,
+) -> Vec<Keypair> {
+    let futures = transaction_batch
+        .into_iter()
+        .map(|(tx, account_keypairs)| async move {
+            let Some(signature) = tx.signatures.first().copied() else {
+                return (false, account_keypairs);
+            };
+
+            let Ok(wire_transaction) = wincode::serialize(&tx) else {
+                return (false, account_keypairs);
+            };
+
+            let success = if transaction_sender
+                .send_transaction(wire_transaction)
+                .await
+                .is_ok()
+            {
+                rpc_client
+                    .confirm_transaction_with_commitment(&signature, CommitmentConfig::finalized())
+                    .await
+                    .map(|response| response.value)
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+
+            (success, account_keypairs)
+        });
+    let results = join_all(futures).await;
+    results
+        .into_iter()
+        .filter_map(|(success, account_keypairs)| success.then_some(account_keypairs))
         .flatten()
         .collect()
 }
@@ -297,6 +462,7 @@ async fn create_accounts(
     num_accounts: usize,
     balance_lamports: u64,
     max_continuos_failed_attempts: usize,
+    transaction_sender: &AccountCreationSender,
 ) -> Vec<Keypair> {
     // It makes sense to send concurrently subset
     // of transactions to avoid having expired block height exceed error.
@@ -348,7 +514,8 @@ async fn create_accounts(
 
         let transaction_batch =
             create_transaction_batch(authorities, blockhash, current_batch_size, balance_lamports);
-        let newly_created_accounts = send_transaction_batch(rpc_client, transaction_batch).await;
+        let newly_created_accounts =
+            send_transaction_batch(rpc_client, transaction_batch, transaction_sender).await;
         num_continuous_failed_attempts = if newly_created_accounts.is_empty() {
             num_continuous_failed_attempts + 1
         } else {
@@ -463,7 +630,15 @@ mod tests {
     async fn test_create_accounts_rpc_always_succeeds() {
         let rpc_client = Arc::new(RpcClient::new_mock("succeeds".to_string()));
 
-        let accounts = create_accounts(&rpc_client, &[Keypair::new()], 128, 1, 10).await;
+        let accounts = create_accounts(
+            &rpc_client,
+            &[Keypair::new()],
+            128,
+            1,
+            10,
+            &AccountCreationSender::Rpc,
+        )
+        .await;
 
         assert_eq!(accounts.len(), 128);
     }
@@ -473,7 +648,15 @@ mod tests {
     async fn test_create_accounts_rpc_always_fails() {
         let rpc_client = Arc::new(RpcClient::new_mock("fails".to_string()));
 
-        let accounts = create_accounts(&rpc_client, &[Keypair::new()], 128, 1, 10).await;
+        let accounts = create_accounts(
+            &rpc_client,
+            &[Keypair::new()],
+            128,
+            1,
+            10,
+            &AccountCreationSender::Rpc,
+        )
+        .await;
 
         assert_eq!(accounts.len(), 0);
     }
@@ -535,7 +718,15 @@ mod tests {
     async fn test_create_accounts_rpc_send_fails() {
         let rpc_client = Arc::new(RpcClient::new_mock("malicious".to_string()));
 
-        let accounts = create_accounts(&rpc_client, &[Keypair::new()], 1, 1, 10).await;
+        let accounts = create_accounts(
+            &rpc_client,
+            &[Keypair::new()],
+            1,
+            1,
+            10,
+            &AccountCreationSender::Rpc,
+        )
+        .await;
 
         assert_eq!(accounts.len(), 0);
     }
@@ -546,7 +737,15 @@ mod tests {
     async fn test_create_accounts_half_rpc_succeeds() {
         let rpc_client = Arc::new(create_mock_rpc_client(&["succeeds", "fails"]));
 
-        let accounts = create_accounts(&rpc_client, &[Keypair::new()], 12, 1, 10).await;
+        let accounts = create_accounts(
+            &rpc_client,
+            &[Keypair::new()],
+            12,
+            1,
+            10,
+            &AccountCreationSender::Rpc,
+        )
+        .await;
 
         assert_eq!(accounts.len(), 12);
     }
@@ -564,7 +763,15 @@ mod tests {
             "sig_not_found",
         ]));
 
-        let accounts = create_accounts(&rpc_client, &[Keypair::new()], 121, 1, 10).await;
+        let accounts = create_accounts(
+            &rpc_client,
+            &[Keypair::new()],
+            121,
+            1,
+            10,
+            &AccountCreationSender::Rpc,
+        )
+        .await;
 
         assert_eq!(accounts.len(), 121);
     }

--- a/tpu-tools-common/src/accounts_file.rs
+++ b/tpu-tools-common/src/accounts_file.rs
@@ -3,7 +3,9 @@
 //! Account files store payer keypairs that can be reused between benchmark
 //! runs, avoiding repeated account creation on public clusters.
 use {
-    crate::accounts_creator::{AccountsCreator, Error as AccountsCreatorError},
+    crate::accounts_creator::{
+        AccountCreationSender, AccountsCreator, Error as AccountsCreatorError,
+    },
     log::error,
     serde::{Deserialize, Serialize},
     solana_keypair::Keypair,
@@ -99,11 +101,32 @@ pub async fn create_ephemeral_accounts(
     payers_account_balance_lamports: u64,
     validate_accounts: bool,
 ) -> Result<AccountsFile, Error> {
-    let accounts_creator = AccountsCreator::new(
+    create_ephemeral_accounts_with_sender(
+        rpc_client,
+        authority,
+        num_payers,
+        payers_account_balance_lamports,
+        validate_accounts,
+        AccountCreationSender::Rpc,
+    )
+    .await
+}
+
+/// Creates payer accounts using the provided transaction sender.
+pub async fn create_ephemeral_accounts_with_sender(
+    rpc_client: Arc<RpcClient>,
+    authority: Keypair,
+    num_payers: usize,
+    payers_account_balance_lamports: u64,
+    validate_accounts: bool,
+    transaction_sender: AccountCreationSender,
+) -> Result<AccountsFile, Error> {
+    let accounts_creator = AccountsCreator::new_with_transaction_sender(
         rpc_client.clone(),
         authority,
         num_payers,
         payers_account_balance_lamports,
+        transaction_sender,
     );
     let accounts = accounts_creator.create().await?;
     if validate_accounts
@@ -133,12 +156,35 @@ pub async fn create_file_persisted_accounts(
     payers_account_balance: u64,
     validate_accounts: bool,
 ) -> Result<(), Error> {
-    let accounts = create_ephemeral_accounts(
+    create_file_persisted_accounts_with_sender(
+        rpc_client,
+        authority,
+        accounts_file,
+        num_payers,
+        payers_account_balance,
+        validate_accounts,
+        AccountCreationSender::Rpc,
+    )
+    .await
+}
+
+/// Creates payer accounts with the provided transaction sender and persists them.
+pub async fn create_file_persisted_accounts_with_sender(
+    rpc_client: Arc<RpcClient>,
+    authority: Keypair,
+    accounts_file: PathBuf,
+    num_payers: usize,
+    payers_account_balance: u64,
+    validate_accounts: bool,
+    transaction_sender: AccountCreationSender,
+) -> Result<(), Error> {
+    let accounts = create_ephemeral_accounts_with_sender(
         rpc_client,
         authority,
         num_payers,
         payers_account_balance,
         validate_accounts,
+        transaction_sender,
     )
     .await?;
 

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -7,10 +7,11 @@ use {
     solana_rpc_client::nonblocking::rpc_client::RpcClient,
     solana_signer::{EncodableKey, Signer},
     solana_tpu_tools_common::{
+        accounts_creator::create_tpu_account_creation_client,
         accounts_deleter::delete_file_persisted_accounts,
         accounts_file::{
-            AccountsFile, create_ephemeral_accounts, create_file_persisted_accounts,
-            read_accounts_file,
+            AccountsFile, create_ephemeral_accounts_with_sender,
+            create_file_persisted_accounts_with_sender, read_accounts_file,
         },
         cli::{LeaderTracker, parse_recipient},
     },
@@ -22,7 +23,13 @@ use {
         mock_rpc_client::new_mock_rpc_client,
         run_client::{ExecutionParams, RunClientStats, run_client},
     },
-    std::{net::SocketAddr, num::NonZeroU64, path::PathBuf, sync::Arc, time::Duration},
+    std::{
+        net::SocketAddr,
+        num::{NonZeroU64, NonZeroUsize},
+        path::PathBuf,
+        sync::Arc,
+        time::Duration,
+    },
     tokio::{sync::oneshot, task::JoinHandle},
     tokio_util::sync::CancellationToken,
 };
@@ -81,6 +88,8 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
             account_params,
             execution_params,
         } => {
+            let cancel = CancellationToken::new();
+            let execution_params = resolve_cli_execution_params(execution_params);
             let accounts = if parameters.mock_rpc {
                 info!(
                     "Skipping payer account creation because --mock-rpc is enabled; generating \
@@ -88,19 +97,35 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
                 );
                 create_mock_accounts(account_params.num_payers)
             } else {
-                create_ephemeral_accounts(
+                let endpoint_config = execution_params
+                    .endpoint_configs
+                    .first()
+                    .cloned()
+                    .expect("resolved endpoint configs should not be empty");
+                let account_creation_client = create_tpu_account_creation_client(
+                    rpc_client.clone(),
+                    execution_params.leader_tracker.clone(),
+                    websocket_url.clone(),
+                    endpoint_config.bind,
+                    endpoint_config.staked_identity_file,
+                    NonZeroUsize::new(execution_params.num_max_open_connections)
+                        .expect("num-max-open-connections must be non-zero"),
+                    execution_params.send_fanout,
+                    cancel.child_token(),
+                )
+                .await?;
+                let accounts = create_ephemeral_accounts_with_sender(
                     rpc_client.clone(),
                     authority,
                     account_params.num_payers,
                     account_params.payer_account_balance,
                     parameters.validate_accounts,
+                    account_creation_client.transaction_sender.clone(),
                 )
-                .await?
+                .await;
+                account_creation_client.shutdown().await?;
+                accounts?
             };
-
-            let execution_params = resolve_cli_execution_params(execution_params);
-
-            let cancel = CancellationToken::new();
             let (stats_sender, stats_receiver) = oneshot::channel();
             let metrics_task = spawn_metrics_reporter(stats_receiver, cancel.clone());
             let result = run_client(
@@ -139,15 +164,32 @@ async fn run(parameters: ClientCliParameters) -> Result<(), BenchClientError> {
             finish_client_run(result, cancel, metrics_task).await?;
         }
         Command::WriteAccounts(write_accounts) => {
-            create_file_persisted_accounts(
+            let cancel = CancellationToken::new();
+            let account_creation_client = create_tpu_account_creation_client(
+                rpc_client.clone(),
+                LeaderTracker::WsLeaderTracker,
+                websocket_url,
+                "0.0.0.0:0"
+                    .parse()
+                    .expect("default bind address should be valid"),
+                None,
+                NonZeroUsize::new(16).expect("default max open connections must be non-zero"),
+                1,
+                cancel.child_token(),
+            )
+            .await?;
+            let result = create_file_persisted_accounts_with_sender(
                 rpc_client.clone(),
                 authority,
                 write_accounts.accounts_file,
                 write_accounts.account_params.num_payers,
                 write_accounts.account_params.payer_account_balance,
                 parameters.validate_accounts,
+                account_creation_client.transaction_sender.clone(),
             )
-            .await?;
+            .await;
+            account_creation_client.shutdown().await?;
+            result?;
         }
         Command::DeleteAccounts(delete_accounts) => {
             if !authority_provided {


### PR DESCRIPTION
## Summary

Use TPU sends for payer account creation instead of submitting create-account transactions through RPC.

The account setup flow still uses RPC for balance checks, airdrops, blockhash/fee lookup, confirmation, and optional validation, but the actual batched `create_account` transactions are now sent through `tpu-client-next`.

## Changes

- Added account-creation sender abstraction in `tpu-tools-common`
- Added TPU-backed account creation using `tpu-client-next::TransactionSender`
- Reused existing leader-tracker configuration for TPU account creation in `run`
- Switched `write-accounts` to create accounts through TPU using the default WS leader tracker
- Kept existing RPC-backed account creation helpers as the default/backward-compatible path
- Added required normal dependencies for TPU account creation serialization/socket binding

## Validation

- `cargo +nightly-2026-05-23 fmt --all`
- `cargo +nightly-2026-05-23 check --locked -p solana-tpu-tools-common -p solana-rate-latency-tool -p solana-transaction-bench --all-targets`
- `cargo +nightly-2026-05-23 clippy -p solana-tpu-tools-common -p solana-rate-latency-tool -p solana-transaction-bench --all-targets -- --deny=warnings --deny=clippy::default_trait_access --deny=clippy::arithmetic_side_effects --deny=clippy::manual_let_else --deny=clippy::uninlined-format-args --deny=clippy::used_underscore_binding`
- `cargo +nightly-2026-05-23 test -p solana-tpu-tools-common accounts_creator::tests --locked`

Part of #108