### PR TITLE
Compute optimal batch size and workers queue size

### DIFF
--- a/transaction-bench/README.md
+++ b/transaction-bench/README.md
@@ -118,9 +118,18 @@ solana-transaction-bench "${args[@]}"
 #### Target TPS
 
 Use `--target-tps` to pace transaction generation instead of sending as fast as
-the generator and connection workers allow. Transaction batches are a generator
-concern only; `--tx-batch-size` controls how many transactions are produced per
-generated batch and defaults to 64.
+the generator and connection workers allow. When `--tx-batch-size` is omitted,
+the generated batch size is `ceil(target_tps / (500 * num_schedulers))`, clamped
+to 8–64 transactions. This targets one batch every 2 ms per scheduler as a sizing
+heuristic. Actual generation pacing follows the resolved batch size and target
+TPS; clamping can make the interval per scheduler differ from 2 ms.
+Each configured endpoint runs one scheduler. Without
+`--target-tps`, the batch size defaults to 64. An explicit `--tx-batch-size`
+overrides this calculation and is not clamped.
+
+Each connection worker's channel capacity is `max(16, 2 * batch_size)`.
+For example, 40,000 TPS with one scheduler uses batches of 64 transactions
+and a worker channel capacity of 128. The resolved sizes are logged at startup.
 
 ```shell
 args=(
@@ -216,8 +225,8 @@ solana -u "$URL" program deploy spl_instruction_padding.so --program-id spl_inst
 #### Transaction Conflicts
 
 Use `--num-conflict-groups` to intentionally reuse destination accounts within each generated
-batch. Lower conflict group counts create more account conflicts. Use `--tx-batch-size` to change
-the generated batch size from its default of 64.
+batch. Lower conflict group counts create more account conflicts. Use `--tx-batch-size` to override
+the generated batch size described under [Target TPS](#target-tps).
 `--num-conflict-groups` must be no greater than `--num-send-instructions-per-tx * --tx-batch-size`.
 
 ```shell

--- a/transaction-bench/src/cli.rs
+++ b/transaction-bench/src/cli.rs
@@ -332,12 +332,14 @@ pub struct SimpleTransferTxParams {
 
     #[clap(
         long,
-        default_value = "64",
         value_parser = value_parser!(NonZeroUsize),
-        help = "Number of transactions per generated batch. This also affects the maximum valid \
-        --num-conflict-groups value: num-send-instructions-per-tx * tx-batch-size."
+        help = "Number of transactions per generated batch. Defaults to \
+                ceil(target-tps / (500 * number of schedulers)), clamped to 8..=64, \
+                or 64 without --target-tps. Worker channel capacity is max(16, 2 * batch size). \
+                This also affects the maximum valid --num-conflict-groups value: \
+                num-send-instructions-per-tx * tx-batch-size."
     )]
-    pub tx_batch_size: NonZeroUsize,
+    pub tx_batch_size: Option<NonZeroUsize>,
 
     #[clap(
         long,
@@ -503,7 +505,7 @@ mod tests {
                         max_lamports_to_transfer: 1000,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
-                        tx_batch_size: NonZeroUsize::new(64).unwrap(),
+                        tx_batch_size: None,
                         num_conflict_groups: None,
                     },
                     padding_params: InstructionPaddingParams {
@@ -558,7 +560,7 @@ mod tests {
                         max_lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                         transfer_tx_cu_budget: 1000,
                         num_send_instructions_per_tx: 2,
-                        tx_batch_size: NonZeroUsize::new(64).unwrap(),
+                        tx_batch_size: None,
                         num_conflict_groups: None,
                     },
                     padding_params: InstructionPaddingParams {
@@ -587,7 +589,7 @@ mod tests {
                 max_lamports_to_transfer: DEFAULT_MAX_LAMPORTS_TO_TRANSFER,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx: 1,
-                tx_batch_size: NonZeroUsize::new(64).unwrap(),
+                tx_batch_size: None,
                 num_conflict_groups: None,
             },
             padding_params: InstructionPaddingParams {
@@ -837,6 +839,47 @@ mod tests {
         let actual = cli.unwrap();
 
         assert_eq!(actual, expected_parameters);
+    }
+
+    #[test]
+    fn test_tx_batch_size_override() {
+        for batch_size in ["1", "512"] {
+            let cli = ClientCliParameters::try_parse_from([
+                "test",
+                "-ul",
+                "read-accounts-run",
+                "--accounts-file",
+                "accounts.json",
+                "--tx-batch-size",
+                batch_size,
+                "ws-leader-tracker",
+            ])
+            .unwrap();
+            let Command::ReadAccountsRun {
+                transaction_params, ..
+            } = cli.command
+            else {
+                panic!("Expected read-accounts-run");
+            };
+            assert_eq!(
+                transaction_params.simple_transfer_tx_params.tx_batch_size,
+                Some(batch_size.parse::<NonZeroUsize>().unwrap())
+            );
+        }
+
+        assert!(
+            ClientCliParameters::try_parse_from([
+                "test",
+                "-ul",
+                "read-accounts-run",
+                "--accounts-file",
+                "accounts.json",
+                "--tx-batch-size",
+                "0",
+                "ws-leader-tracker",
+            ])
+            .is_err()
+        );
     }
 
     #[test]

--- a/transaction-bench/src/generator/transaction_generator.rs
+++ b/transaction-bench/src/generator/transaction_generator.rs
@@ -453,7 +453,7 @@ mod tests {
                 max_lamports_to_transfer: 513,
                 transfer_tx_cu_budget: 600,
                 num_send_instructions_per_tx,
-                tx_batch_size: NonZeroUsize::new(64).unwrap(),
+                tx_batch_size: NonZeroUsize::new(64),
                 num_conflict_groups: None,
             },
             padding_params: InstructionPaddingParams {

--- a/transaction-bench/src/main.rs
+++ b/transaction-bench/src/main.rs
@@ -419,7 +419,7 @@ mod tests {
                         max_lamports_to_transfer: 513,
                         transfer_tx_cu_budget: 600,
                         num_send_instructions_per_tx: 1,
-                        tx_batch_size: NonZeroUsize::new(64).unwrap(),
+                        tx_batch_size: None,
                         num_conflict_groups: None,
                     },
                     padding_params: InstructionPaddingParams {

--- a/transaction-bench/src/run_client.rs
+++ b/transaction-bench/src/run_client.rs
@@ -31,9 +31,6 @@ use {
     tokio_util::sync::CancellationToken,
 };
 
-/// Empirically chosen size of the connection worker channel. Lower/higher values gives
-/// significantly smaller txs blocks on testnet.
-const WORKER_CHANNEL_SIZE: usize = 20;
 /// Number of reconnection attempts, a reasonable value that have been chosen,
 /// doesn't affect TPS.
 const MAX_RECONNECT_ATTEMPTS: usize = 5;
@@ -88,14 +85,24 @@ pub async fn run_client(
         .map(load_identity)
         .collect::<Result<Vec<_>, _>>()?;
 
-    let generate_tx_batch_size = transaction_params
-        .simple_transfer_tx_params
-        .tx_batch_size
-        .get();
+    let num_schedulers = NonZeroUsize::new(endpoint_configs.len()).ok_or_else(|| {
+        BenchClientError::InvalidCliArguments("At least one endpoint is required".to_string())
+    })?;
+    let generate_tx_batch_size = resolve_batch_size(
+        transaction_params.simple_transfer_tx_params.tx_batch_size,
+        target_tps,
+        num_schedulers,
+    );
+    let worker_channel_size = generate_tx_batch_size.saturating_mul(2).max(16);
+
     let generator_channel_size = workers_pull_size.saturating_mul(generate_tx_batch_size);
     if let Some(target_tps) = target_tps {
         info!("Using {workers_pull_size} generator workers for target {target_tps} tx/s.");
     }
+    info!(
+        "Using batch size {generate_tx_batch_size} and worker channel capacity \
+         {worker_channel_size} across {num_schedulers} schedulers."
+    );
 
     {
         let transfer_instructions_per_tx = transaction_params
@@ -209,6 +216,7 @@ pub async fn run_client(
         &leader_updater_factory,
         SchedulerConnectionParams {
             num_max_open_connections,
+            worker_channel_size,
             send_fanout,
             initial_congestion_window,
         },
@@ -264,6 +272,31 @@ pub async fn run_client(
     Ok(())
 }
 
+fn resolve_batch_size(
+    tx_batch_size: Option<NonZeroUsize>,
+    target_tps: Option<u64>,
+    num_schedulers: NonZeroUsize,
+) -> usize {
+    const MIN_BATCH_SIZE: usize = 8;
+    const MAX_BATCH_SIZE: usize = 64;
+    // Heuristic target interval per scheduler used to size batches. Chosen as 2 ms after
+    // observing ~1.12 ms to generate 64 transactions in a local run; not a measured optimum.
+    // Actual generation pacing follows batch size and target TPS, so clamping can change
+    // the interval per scheduler.
+    const TARGET_BATCH_INTERVAL_PER_SCHEDULER_MS: u64 = 2;
+
+    tx_batch_size.map(NonZeroUsize::get).unwrap_or_else(|| {
+        target_tps.map_or(MAX_BATCH_SIZE, |target_tps| {
+            let num_schedulers = u64::try_from(num_schedulers.get()).unwrap();
+            let batches_per_second =
+                (1000 / TARGET_BATCH_INTERVAL_PER_SCHEDULER_MS).saturating_mul(num_schedulers);
+            target_tps
+                .div_ceil(batches_per_second)
+                .clamp(MIN_BATCH_SIZE as u64, MAX_BATCH_SIZE as u64) as usize
+        })
+    })
+}
+
 fn load_identity(endpoint_config: &EndpointConfig) -> Result<Option<Keypair>, BenchClientError> {
     endpoint_config
         .staked_identity_file
@@ -277,6 +310,7 @@ fn load_identity(endpoint_config: &EndpointConfig) -> Result<Option<Keypair>, Be
 
 struct SchedulerConnectionParams {
     num_max_open_connections: usize,
+    worker_channel_size: usize,
     send_fanout: usize,
     initial_congestion_window: Option<u64>,
 }
@@ -311,7 +345,7 @@ async fn build_schedulers(
             stake_identity,
             num_connections: NonZeroUsize::new(scheduler_params.num_max_open_connections)
                 .expect("num-max-open-connections must be non-zero"),
-            worker_channel_size: WORKER_CHANNEL_SIZE,
+            worker_channel_size: scheduler_params.worker_channel_size,
             max_reconnect_attempts: MAX_RECONNECT_ATTEMPTS,
             leaders_fanout: Fanout {
                 send: scheduler_params.send_fanout,
@@ -364,6 +398,57 @@ where
                 task_name: task_name.to_string(),
                 reason: e.to_string(),
             })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_automatic_batch_size() {
+        for (target_tps, num_schedulers, expected) in [
+            (None, 1, 64),
+            (None, 4, 64),
+            (Some(1), 1, 8),
+            (Some(4_000), 1, 8),
+            (Some(4_001), 1, 9),
+            (Some(5_000), 1, 10),
+            (Some(5_001), 2, 8),
+            (Some(8_000), 2, 8),
+            (Some(8_001), 2, 9),
+            (Some(25_001), 2, 26),
+            (Some(32_000), 1, 64),
+            (Some(32_001), 1, 64),
+            (Some(40_000), 1, 64),
+            (Some(40_000), 2, 40),
+            (Some(64_000), 2, 64),
+            (Some(64_001), 2, 64),
+            (Some(u64::MAX), 1, 64),
+            (Some(40_000), usize::MAX, 8),
+        ] {
+            assert_eq!(
+                resolve_batch_size(None, target_tps, NonZeroUsize::new(num_schedulers).unwrap()),
+                expected,
+                "target TPS: {target_tps:?}, schedulers: {num_schedulers}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_explicit_batch_size_is_not_clamped() {
+        for batch_size in [1, 64, 512] {
+            for target_tps in [None, Some(40_000)] {
+                assert_eq!(
+                    resolve_batch_size(
+                        NonZeroUsize::new(batch_size),
+                        target_tps,
+                        NonZeroUsize::new(2).unwrap(),
+                    ),
+                    batch_size
+                );
+            }
         }
     }
 }

--- a/transaction-bench/tests/run_client.rs
+++ b/transaction-bench/tests/run_client.rs
@@ -127,7 +127,7 @@ fn test_transactions_sending() {
                     max_lamports_to_transfer: 513,
                     transfer_tx_cu_budget: 600,
                     num_send_instructions_per_tx: 1,
-                    tx_batch_size: NonZeroUsize::new(64).unwrap(),
+                    tx_batch_size: NonZeroUsize::new(64),
                     num_conflict_groups: None,
                 },
                 padding_params: InstructionPaddingParams {


### PR DESCRIPTION
Currently we configure manually batch size while workers queue size is fixed. This is suboptimal.

The new code computes both parameters based on specified `--target-tps` along with number of schedulers.